### PR TITLE
UCDXML 15.0 Draft 2 (Beta)

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -2222,78 +2222,78 @@ of the copyright holder.
     <mkdir dir='data/15.0.0/ucd/emoji'/>
 
     <get src='${Public}/15.0.0/ucd/ArabicShaping-15.0.0d1.txt'                  dest='data/15.0.0/ucd/ArabicShaping.txt'/>
-    <get src='${Public}/14.0.0/ucd/BidiBrackets.txt'                            dest='data/15.0.0/ucd/BidiBrackets.txt'/>
-    <get src='${Public}/14.0.0/ucd/BidiCharacterTest.txt'                       dest='data/15.0.0/ucd/BidiCharacterTest.txt'/>
-    <get src='${Public}/14.0.0/ucd/BidiMirroring.txt'                           dest='data/15.0.0/ucd/BidiMirroring.txt'/>
-    <get src='${Public}/14.0.0/ucd/BidiTest.txt'                                dest='data/15.0.0/ucd/BidiTest.txt'/>
+    <get src='${Public}/15.0.0/ucd/BidiBrackets-15.0.0d1.txt'                   dest='data/15.0.0/ucd/BidiBrackets.txt'/>
+    <get src='${Public}/15.0.0/ucd/BidiCharacterTest-15.0.0d1.txt'              dest='data/15.0.0/ucd/BidiCharacterTest.txt'/>
+    <get src='${Public}/15.0.0/ucd/BidiMirroring-15.0.0d1.txt'                  dest='data/15.0.0/ucd/BidiMirroring.txt'/>
+    <get src='${Public}/15.0.0/ucd/BidiTest-15.0.0d1.txt'                       dest='data/15.0.0/ucd/BidiTest.txt'/>
     <get src='${Public}/15.0.0/ucd/Blocks-15.0.0d3.txt'                         dest='data/15.0.0/ucd/Blocks.txt'/>
-    <get src='${Public}/14.0.0/ucd/CJKRadicals.txt'                             dest='data/15.0.0/ucd/CJKRadicals.txt'/>
-    <get src='${Public}/14.0.0/ucd/CaseFolding.txt'                             dest='data/15.0.0/ucd/CaseFolding.txt'/>
-    <get src='${Public}/14.0.0/ucd/CompositionExclusions.txt'                   dest='data/15.0.0/ucd/CompositionExclusions.txt'/>
-    <get src='${Public}/15.0.0/ucd/DerivedAge-15.0.0d1.txt'                     dest='data/15.0.0/ucd/DerivedAge.txt'/>
-    <get src='${Public}/14.0.0/ucd/DerivedCoreProperties.txt'                   dest='data/15.0.0/ucd/DerivedCoreProperties.txt'/>
-    <get src='${Public}/14.0.0/ucd/DerivedNormalizationProps.txt'               dest='data/15.0.0/ucd/DerivedNormalizationProps.txt'/>
-    <get src='${Public}/15.0.0/ucd/EastAsianWidth-15.0.0d3.txt'                 dest='data/15.0.0/ucd/EastAsianWidth.txt'/>
-    <get src='${Public}/14.0.0/ucd/EmojiSources.txt'                            dest='data/15.0.0/ucd/EmojiSources.txt'/>
-    <get src='${Public}/14.0.0/ucd/EquivalentUnifiedIdeograph.txt'              dest='data/15.0.0/ucd/EquivalentUnifiedIdeograph.txt'/>
-    <get src='${Public}/14.0.0/ucd/HangulSyllableType.txt'                      dest='data/15.0.0/ucd/HangulSyllableType.txt'/>
-    <get src='${Public}/14.0.0/ucd/Index.txt'                                   dest='data/15.0.0/ucd/Index.txt'/>
+    <get src='${Public}/15.0.0/ucd/CJKRadicals-15.0.0d1.txt'                    dest='data/15.0.0/ucd/CJKRadicals.txt'/>
+    <get src='${Public}/15.0.0/ucd/CaseFolding-15.0.0d1.txt'                    dest='data/15.0.0/ucd/CaseFolding.txt'/>
+    <get src='${Public}/15.0.0/ucd/CompositionExclusions-15.0.0d1.txt'          dest='data/15.0.0/ucd/CompositionExclusions.txt'/>
+    <get src='${Public}/15.0.0/ucd/DerivedAge-15.0.0d2.txt'                     dest='data/15.0.0/ucd/DerivedAge.txt'/>
+    <get src='${Public}/15.0.0/ucd/DerivedCoreProperties-15.0.0d1.txt'          dest='data/15.0.0/ucd/DerivedCoreProperties.txt'/>
+    <get src='${Public}/15.0.0/ucd/DerivedNormalizationProps-15.0.0d1.txt'      dest='data/15.0.0/ucd/DerivedNormalizationProps.txt'/>
+    <get src='${Public}/15.0.0/ucd/EastAsianWidth-15.0.0d5.txt'                 dest='data/15.0.0/ucd/EastAsianWidth.txt'/>
+    <get src='${Public}/15.0.0/ucd/EmojiSources-15.0.0d1.txt'                   dest='data/15.0.0/ucd/EmojiSources.txt'/>
+    <get src='${Public}/15.0.0/ucd/EquivalentUnifiedIdeograph-15.0.0d1.txt'     dest='data/15.0.0/ucd/EquivalentUnifiedIdeograph.txt'/>
+    <get src='${Public}/15.0.0/ucd/HangulSyllableType-15.0.0d1.txt'             dest='data/15.0.0/ucd/HangulSyllableType.txt'/>
+    <get src='${Public}/15.0.0/ucd/Index-15.0.0d1.txt'                          dest='data/15.0.0/ucd/Index.txt'/>
     <get src='${Public}/15.0.0/ucd/IndicPositionalCategory-15.0.0d6.txt'        dest='data/15.0.0/ucd/IndicPositionalCategory.txt'/>
     <get src='${Public}/15.0.0/ucd/IndicSyllabicCategory-15.0.0d5.txt'          dest='data/15.0.0/ucd/IndicSyllabicCategory.txt'/>
-    <get src='${Public}/14.0.0/ucd/Jamo.txt'                                    dest='data/15.0.0/ucd/Jamo.txt'/>
-    <get src='${Public}/15.0.0/ucd/LineBreak-15.0.0d3.txt'                      dest='data/15.0.0/ucd/LineBreak.txt'/>
+    <get src='${Public}/15.0.0/ucd/Jamo-15.0.0d1.txt'                           dest='data/15.0.0/ucd/Jamo.txt'/>
+    <get src='${Public}/15.0.0/ucd/LineBreak-15.0.0d6.txt'                      dest='data/15.0.0/ucd/LineBreak.txt'/>
     <get src='${Public}/15.0.0/ucd/NameAliases-15.0.0d2.txt'                    dest='data/15.0.0/ucd/NameAliases.txt'/>
     <get src='${Public}/15.0.0/ucd/NamedSequences-15.0.0d1.txt'                 dest='data/15.0.0/ucd/NamedSequences.txt'/>
     <get src='${Public}/15.0.0/ucd/NamedSequencesProv-15.0.0d1.txt'             dest='data/15.0.0/ucd/NamedSequencesProv.txt'/>
-    <get src='${Public}/14.0.0/ucd/NamesList.html'                              dest='data/15.0.0/ucd/NamesList.html'/>
-    <get src='${Public}/15.0.0/ucd/NamesList-15.0.0d2.txt'                      dest='data/15.0.0/ucd/NamesList.txt'/>
-    <get src='${Public}/14.0.0/ucd/NormalizationCorrections.txt'                dest='data/15.0.0/ucd/NormalizationCorrections.txt'/>
-    <get src='${Public}/14.0.0/ucd/NormalizationTest.txt'                       dest='data/15.0.0/ucd/NormalizationTest.txt'/>
-    <get src='${Public}/14.0.0/ucd/NushuSources.txt'                            dest='data/15.0.0/ucd/NushuSources.txt'/>
-    <get src='${Public}/15.0.0/ucd/PropList-15.0.0d2.txt'                       dest='data/15.0.0/ucd/PropList.txt'/>
-    <get src='${Public}/14.0.0/ucd/PropertyAliases.txt'                         dest='data/15.0.0/ucd/PropertyAliases.txt'/>
-    <get src='${Public}/14.0.0/ucd/PropertyValueAliases.txt'                    dest='data/15.0.0/ucd/PropertyValueAliases.txt'/>
+    <get src='${Public}/15.0.0/ucd/NamesList-15.0.0d1.html'                     dest='data/15.0.0/ucd/NamesList.html'/>
+    <get src='${Public}/15.0.0/ucd/NamesList-15.0.0d5.txt'                      dest='data/15.0.0/ucd/NamesList.txt'/>
+    <get src='${Public}/15.0.0/ucd/NormalizationCorrections-15.0.0d1.txt'       dest='data/15.0.0/ucd/NormalizationCorrections.txt'/>
+    <get src='${Public}/15.0.0/ucd/NormalizationTest-15.0.0d1.txt'              dest='data/15.0.0/ucd/NormalizationTest.txt'/>
+    <get src='${Public}/15.0.0/ucd/NushuSources-15.0.0d1.txt'                   dest='data/15.0.0/ucd/NushuSources.txt'/>
+    <get src='${Public}/15.0.0/ucd/PropList-15.0.0d3.txt'                       dest='data/15.0.0/ucd/PropList.txt'/>
+    <get src='${Public}/15.0.0/ucd/PropertyAliases-15.0.0d1.txt'                dest='data/15.0.0/ucd/PropertyAliases.txt'/>
+    <get src='${Public}/15.0.0/ucd/PropertyValueAliases-15.0.0d1.txt'           dest='data/15.0.0/ucd/PropertyValueAliases.txt'/>
     <get src='${Public}/15.0.0/ucd/ReadMe-15.0.0d1.txt'                         dest='data/15.0.0/ucd/ReadMe.txt'/>
     <get src='${Public}/15.0.0/ucd/ScriptExtensions-15.0.0d1.txt'               dest='data/15.0.0/ucd/ScriptExtensions.txt'/>
-    <get src='${Public}/15.0.0/ucd/Scripts-15.0.0d4.txt'                        dest='data/15.0.0/ucd/Scripts.txt'/>
-    <get src='${Public}/14.0.0/ucd/SpecialCasing.txt'                           dest='data/15.0.0/ucd/SpecialCasing.txt'/>
+    <get src='${Public}/15.0.0/ucd/Scripts-15.0.0d5.txt'                        dest='data/15.0.0/ucd/Scripts.txt'/>
+    <get src='${Public}/15.0.0/ucd/SpecialCasing-15.0.0d1.txt'                  dest='data/15.0.0/ucd/SpecialCasing.txt'/>
     <get src='${Public}/15.0.0/ucd/StandardizedVariants-15.0.0d2.txt'           dest='data/15.0.0/ucd/StandardizedVariants.txt'/>
-    <get src='${Public}/14.0.0/ucd/TangutSources.txt'                           dest='data/15.0.0/ucd/TangutSources.txt'/>
-    <get src='${Public}/15.0.0/ucd/USourceData-15.0.0d2.txt'                    dest='data/15.0.0/ucd/USourceData.txt'/>
-    <get src='${Public}/15.0.0/ucd/USourceGlyphs-15.0.0d3.pdf'                  dest='data/15.0.0/ucd/USourceGlyphs.pdf'/>
-    <get src='${Public}/15.0.0/ucd/USourceRSChart-15.0.0d3.pdf'                 dest='data/15.0.0/ucd/USourceRSChart.pdf'/>
-    <get src='${Public}/15.0.0/ucd/UnicodeData-15.0.0d5.txt'                    dest='data/15.0.0/ucd/UnicodeData.txt'/>
-    <get src='${Public}/15.0.0/ucd/Unihan-15.0.0d2.zip'                         dest='data/15.0.0/ucd/Unihan.zip'/>
-    <get src='${Public}/15.0.0/ucd/VerticalOrientation-15.0.0d1.txt'            dest='data/15.0.0/ucd/VerticalOrientation.txt'/>
+    <get src='${Public}/15.0.0/ucd/TangutSources-15.0.0d1.txt'                  dest='data/15.0.0/ucd/TangutSources.txt'/>
+    <get src='${Public}/15.0.0/ucd/USourceData-15.0.0d3.txt'                    dest='data/15.0.0/ucd/USourceData.txt'/>
+    <get src='${Public}/15.0.0/ucd/USourceGlyphs-15.0.0d4.pdf'                  dest='data/15.0.0/ucd/USourceGlyphs.pdf'/>
+    <get src='${Public}/15.0.0/ucd/USourceRSChart-15.0.0d4.pdf'                 dest='data/15.0.0/ucd/USourceRSChart.pdf'/>
+    <get src='${Public}/15.0.0/ucd/UnicodeData-15.0.0d6.txt'                    dest='data/15.0.0/ucd/UnicodeData.txt'/>
+    <get src='${Public}/15.0.0/ucd/Unihan-15.0.0d4.zip'                         dest='data/15.0.0/ucd/Unihan.zip'/>
+    <get src='${Public}/15.0.0/ucd/VerticalOrientation-15.0.0d2.txt'            dest='data/15.0.0/ucd/VerticalOrientation.txt'/>
 
-    <get src='${Public}/14.0.0/ucd/extracted/DerivedBidiClass.txt'              dest='data/15.0.0/ucd/extracted/DerivedBidiClass.txt'/>
-    <get src='${Public}/14.0.0/ucd/extracted/DerivedBinaryProperties.txt'       dest='data/15.0.0/ucd/extracted/DerivedBinaryProperties.txt'/>
-    <get src='${Public}/14.0.0/ucd/extracted/DerivedCombiningClass.txt'         dest='data/15.0.0/ucd/extracted/DerivedCombiningClass.txt'/>
-    <get src='${Public}/14.0.0/ucd/extracted/DerivedDecompositionType.txt'      dest='data/15.0.0/ucd/extracted/DerivedDecompositionType.txt'/>
-    <get src='${Public}/14.0.0/ucd/extracted/DerivedEastAsianWidth.txt'         dest='data/15.0.0/ucd/extracted/DerivedEastAsianWidth.txt'/>
-    <get src='${Public}/14.0.0/ucd/extracted/DerivedGeneralCategory.txt'        dest='data/15.0.0/ucd/extracted/DerivedGeneralCategory.txt'/>
-    <get src='${Public}/14.0.0/ucd/extracted/DerivedJoiningGroup.txt'           dest='data/15.0.0/ucd/extracted/DerivedJoiningGroup.txt'/>
-    <get src='${Public}/14.0.0/ucd/extracted/DerivedJoiningType.txt'            dest='data/15.0.0/ucd/extracted/DerivedJoiningType.txt'/>
-    <get src='${Public}/14.0.0/ucd/extracted/DerivedLineBreak.txt'              dest='data/15.0.0/ucd/extracted/DerivedLineBreak.txt'/>
-    <get src='${Public}/14.0.0/ucd/extracted/DerivedName.txt'                   dest='data/15.0.0/ucd/extracted/DerivedName.txt'/>
-    <get src='${Public}/14.0.0/ucd/extracted/DerivedNumericType.txt'            dest='data/15.0.0/ucd/extracted/DerivedNumericType.txt'/>
-    <get src='${Public}/14.0.0/ucd/extracted/DerivedNumericValues.txt'          dest='data/15.0.0/ucd/extracted/DerivedNumericValues.txt'/>
+    <get src='${Public}/15.0.0/ucd/extracted/DerivedBidiClass-15.0.0d1.txt'             dest='data/15.0.0/ucd/extracted/DerivedBidiClass.txt'/>
+    <get src='${Public}/15.0.0/ucd/extracted/DerivedBinaryProperties-15.0.0d1.txt'      dest='data/15.0.0/ucd/extracted/DerivedBinaryProperties.txt'/>
+    <get src='${Public}/15.0.0/ucd/extracted/DerivedCombiningClass-15.0.0d1.txt'        dest='data/15.0.0/ucd/extracted/DerivedCombiningClass.txt'/>
+    <get src='${Public}/15.0.0/ucd/extracted/DerivedDecompositionType-15.0.0d1.txt'     dest='data/15.0.0/ucd/extracted/DerivedDecompositionType.txt'/>
+    <get src='${Public}/15.0.0/ucd/extracted/DerivedEastAsianWidth-15.0.0d1.txt'        dest='data/15.0.0/ucd/extracted/DerivedEastAsianWidth.txt'/>
+    <get src='${Public}/15.0.0/ucd/extracted/DerivedGeneralCategory-15.0.0d1.txt'       dest='data/15.0.0/ucd/extracted/DerivedGeneralCategory.txt'/>
+    <get src='${Public}/15.0.0/ucd/extracted/DerivedJoiningGroup-15.0.0d1.txt'          dest='data/15.0.0/ucd/extracted/DerivedJoiningGroup.txt'/>
+    <get src='${Public}/15.0.0/ucd/extracted/DerivedJoiningType-15.0.0d1.txt'           dest='data/15.0.0/ucd/extracted/DerivedJoiningType.txt'/>
+    <get src='${Public}/15.0.0/ucd/extracted/DerivedLineBreak-15.0.0d2.txt'             dest='data/15.0.0/ucd/extracted/DerivedLineBreak.txt'/>
+    <get src='${Public}/15.0.0/ucd/extracted/DerivedName-15.0.0d1.txt'                  dest='data/15.0.0/ucd/extracted/DerivedName.txt'/>
+    <get src='${Public}/15.0.0/ucd/extracted/DerivedNumericType-15.0.0d1.txt'           dest='data/15.0.0/ucd/extracted/DerivedNumericType.txt'/>
+    <get src='${Public}/15.0.0/ucd/extracted/DerivedNumericValues-15.0.0d1.txt'         dest='data/15.0.0/ucd/extracted/DerivedNumericValues.txt'/>
 
-    <get src='${Public}/14.0.0/ucd/auxiliary/GraphemeBreakProperty.txt'         dest='data/15.0.0/ucd/auxiliary/GraphemeBreakProperty.txt'/>
-    <get src='${Public}/14.0.0/ucd/auxiliary/GraphemeBreakTest.html'            dest='data/15.0.0/ucd/auxiliary/GraphemeBreakTest.html'/>
-    <get src='${Public}/14.0.0/ucd/auxiliary/GraphemeBreakTest.txt'             dest='data/15.0.0/ucd/auxiliary/GraphemeBreakTest.txt'/>
-    <get src='${Public}/14.0.0/ucd/auxiliary/LineBreakTest.html'                dest='data/15.0.0/ucd/auxiliary/LineBreakTest.html'/>
-    <get src='${Public}/14.0.0/ucd/auxiliary/LineBreakTest.txt'                 dest='data/15.0.0/ucd/auxiliary/LineBreakTest.txt'/>
-    <get src='${Public}/14.0.0/ucd/auxiliary/SentenceBreakProperty.txt'         dest='data/15.0.0/ucd/auxiliary/SentenceBreakProperty.txt'/>
-    <get src='${Public}/14.0.0/ucd/auxiliary/SentenceBreakTest.html'            dest='data/15.0.0/ucd/auxiliary/SentenceBreakTest.html'/>
-    <get src='${Public}/14.0.0/ucd/auxiliary/SentenceBreakTest.txt'             dest='data/15.0.0/ucd/auxiliary/SentenceBreakTest.txt'/>
-    <get src='${Public}/14.0.0/ucd/auxiliary/WordBreakProperty.txt'             dest='data/15.0.0/ucd/auxiliary/WordBreakProperty.txt'/>
-    <get src='${Public}/14.0.0/ucd/auxiliary/WordBreakTest.html'                dest='data/15.0.0/ucd/auxiliary/WordBreakTest.html'/>
-    <get src='${Public}/14.0.0/ucd/auxiliary/WordBreakTest.txt'                 dest='data/15.0.0/ucd/auxiliary/WordBreakTest.txt'/>
+    <get src='${Public}/15.0.0/ucd/auxiliary/GraphemeBreakProperty-15.0.0d2.txt'        dest='data/15.0.0/ucd/auxiliary/GraphemeBreakProperty.txt'/>
+    <get src='${Public}/15.0.0/ucd/auxiliary/GraphemeBreakTest-15.0.0d1.html'           dest='data/15.0.0/ucd/auxiliary/GraphemeBreakTest.html'/>
+    <get src='${Public}/15.0.0/ucd/auxiliary/GraphemeBreakTest-15.0.0d1.txt'            dest='data/15.0.0/ucd/auxiliary/GraphemeBreakTest.txt'/>
+    <get src='${Public}/15.0.0/ucd/auxiliary/LineBreakTest-15.0.0d1.html'               dest='data/15.0.0/ucd/auxiliary/LineBreakTest.html'/>
+    <get src='${Public}/15.0.0/ucd/auxiliary/LineBreakTest-15.0.0d1.txt'                dest='data/15.0.0/ucd/auxiliary/LineBreakTest.txt'/>
+    <get src='${Public}/15.0.0/ucd/auxiliary/SentenceBreakProperty-15.0.0d1.txt'        dest='data/15.0.0/ucd/auxiliary/SentenceBreakProperty.txt'/>
+    <get src='${Public}/15.0.0/ucd/auxiliary/SentenceBreakTest-15.0.0d1.html'           dest='data/15.0.0/ucd/auxiliary/SentenceBreakTest.html'/>
+    <get src='${Public}/15.0.0/ucd/auxiliary/SentenceBreakTest-15.0.0d1.txt'            dest='data/15.0.0/ucd/auxiliary/SentenceBreakTest.txt'/>
+    <get src='${Public}/15.0.0/ucd/auxiliary/WordBreakProperty-15.0.0d1.txt'            dest='data/15.0.0/ucd/auxiliary/WordBreakProperty.txt'/>
+    <get src='${Public}/15.0.0/ucd/auxiliary/WordBreakTest-15.0.0d1.html'               dest='data/15.0.0/ucd/auxiliary/WordBreakTest.html'/>
+    <get src='${Public}/15.0.0/ucd/auxiliary/WordBreakTest-15.0.0d1.txt'                dest='data/15.0.0/ucd/auxiliary/WordBreakTest.txt'/>
 
-    <get src='${Public}/14.0.0/ucd/emoji/ReadMe.txt'                            dest='data/15.0.0/ucd/emoji/ReadMe.txt'/>
-    <get src='${Public}/14.0.0/ucd/emoji/emoji-data.txt'                        dest='data/15.0.0/ucd/emoji/emoji-data.txt'/>
-    <get src='${Public}/14.0.0/ucd/emoji/emoji-variation-sequences.txt'         dest='data/15.0.0/ucd/emoji/emoji-variation-sequences.txt'/>
+    <get src='${Public}/15.0.0/ucd/emoji/ReadMe.txt'                            dest='data/15.0.0/ucd/emoji/ReadMe.txt'/>
+    <get src='${Public}/15.0.0/ucd/emoji/emoji-data.txt'                        dest='data/15.0.0/ucd/emoji/emoji-data.txt'/>
+    <get src='${Public}/15.0.0/ucd/emoji/emoji-variation-sequences.txt'         dest='data/15.0.0/ucd/emoji/emoji-variation-sequences.txt'/>
 
     <unzip src='data/15.0.0/ucd/Unihan.zip' dest='data/15.0.0/ucd'/>
     <delete file='data/15.0.0/ucd/Unihan.zip'/>

--- a/readmes/diffs.readme.txt
+++ b/readmes/diffs.readme.txt
@@ -1,7 +1,7 @@
 The beta version of the UCD includes nine files which are intended to
 help beta testers evaluate the changes since the previous
 version. Those files are not part of the UCD, and will be present only
-during the beta period.  Those files only informative. While we
+during the beta period. Those files are only informative. While we
 believe that those files present accurate data, there is no guarantee
 that the data is indeed accurate. The files are not intended to be
 machine readable.
@@ -16,12 +16,12 @@ All files cover:
 - the changes to blocks
 - the changes to named sequences
 - the changes to normalization corrections
-- the changes to standardized variant
+- the changes to standardized variants
 
 
 The *.summary.diffs files give only a summary, in the form of the number of
 things which have changed; the *.changes.diffs file add a list of the new
-characters, and a lists of the property changes for existing
+characters, and a list of the property changes for existing
 characters; the *.all.diffs file adds the property changes for the new
 characters.
 
@@ -31,7 +31,7 @@ the Unihan database. The *.all.* files cover all the properties.
 
 ---
 <x>-<y>.nounihan.summary.diffs contains only the number of things
-(code points, blocks, etc) which have changed between versions
+(code points, blocks, etc.) which have changed between versions
 <x> and <y>. The format is
 
 <before> + <added> - <removed> # <changed> = <after> (<ignored>, <undefined>)
@@ -56,7 +56,7 @@ standardized variants are listed.
 <x>-<y>.nounihan.all.diffs does not ignore the newly assigned
 characters. The most important consequence is that if a property of a
 newly assigned code point has changed, then the change is counted and
-listed. However, this does not means that all the values of the
+listed. However, this does not mean that all the values of the
 properties for all the newly assigned characters are listed: for
 example, the combining class of unassigned code points is 0, and it
 remains 0 for most newly assigned characters. Hence only a subset

--- a/readmes/ucdxml.readme.txt
+++ b/readmes/ucdxml.readme.txt
@@ -1,13 +1,13 @@
-XML Representation of Unicode 13.0.0 UCD
+XML Representation of Unicode 15.0.0 UCD
 
 
-© 2020 Unicode®, Inc.
-For terms of use, see http://www.unicode.org/terms_of_use.html
+© 2022 Unicode®, Inc.
+For terms of use, see https://www.unicode.org/terms_of_use.html
 
 
-This directory contains the representation in XML of version 13.0.0 of
-the UCD, using the schema defined by UAX 42, "Unicode Character
-Database in XML".
+This directory contains the representation in XML of Version 15.0.0 of
+the UCD, using the schema defined by UAX #42: Unicode Character
+Database in XML, at https://www.unicode.org/reports/tr42/
 
 While every effort has been made to ensure consistency of the 
 XML representation with the UCD files, there may be some errors;
@@ -19,9 +19,9 @@ the archive:
 
                     flat         grouped
 
-no Unihan data       936 KB          568 KB
-Unihan data only   6,116 KB        6,124 KB
-complete UCD       8,024 KB        6,652 KB
+no Unihan data       959 KB          580 KB
+Unihan data only   6,383 KB        6,387 KB
+complete UCD       8,357 KB        6,650 KB
 
 The flat versions do not use the group mechanism. The grouped versions
 use the group mechanism, with groups corresponding approximately to
@@ -30,4 +30,4 @@ the blocks (a few blocks have been subdivided).
 The "no Unihan data" files do not contain the properties expressed only
 in the Unihan database. The "Unihan data only" files contain only
 the properties and code points expressed in the Unihan database.
-The "complete  UCD" files reflect the complete UCD data.
+The "complete UCD" files reflect the complete UCD data.

--- a/uax42/index.xml
+++ b/uax42/index.xml
@@ -6,7 +6,7 @@
   <title>Unicode Character Database in XML</title>
 
   <articleinfo>
-    <unicode:tr number='42' class='uax' version='15.0.0 (draft 1)'
+    <unicode:tr number='42' class='uax' version='15.0.0 (draft 2)'
                 stage='proposed-update' status='published'
                 schema='rnc' prevrev='30'/>
 
@@ -21,7 +21,7 @@
     <revhistory>
       <revision>
         <revnumber>31</revnumber>
-        <date>2022-03-31</date>
+        <date>2022-05-24</date>
         <revdescription>
           <itemizedlist>
             <listitem><para>New value for the <sgmltag>age</sgmltag> attribute:
@@ -2487,8 +2487,7 @@
      { text }?
 
   <phrase revisionflag='added'>code-point-attributes &amp;= attribute kAlternateTotalStrokes
-     { list { ( xsd:string {pattern="[0-9]+:[BHJKMPSUV]+"}
-              | xsd:string {pattern="\-"} ) + }}?</phrase>
+     { "-" | list { xsd:string {pattern="[0-9]+:[BHJKMPSUV]+"} +}}?</phrase>
 
   code-point-attributes &amp;= attribute kBigFive
      { xsd:string {pattern="[0-9A-F]{4}"} }?
@@ -2660,7 +2659,7 @@
           | xsd:string {pattern="GXHZ-[0-9]{3}"}
           <phrase revisionflag='added'>| xsd:string {pattern="GXM-[0-9]{5}"}</phrase>
           | xsd:string {pattern="GZ-[0-9]{7}"}
-          <phrase revisionflag='added'>| xsd:string {pattern="GZA-[123467][0-9]{5}"}</phrase>
+          <phrase revisionflag='added'>| xsd:string {pattern="GZA-[0-9]{6}"}</phrase>
           | xsd:string {pattern="GZFY-[0-9]{5}"}
           | xsd:string {pattern="GZH-[0-9]{4}\.[0-9]{2}"}
           | xsd:string {pattern="GZJW-[0-9]{5}"}

--- a/uax42/tr42-31.html
+++ b/uax42/tr42-31.html
@@ -34,7 +34,7 @@
             <tbody>
                <tr>
                   <td valign="top" width="20%">Version</td>
-                  <td valign="top">Unicode <span style="background-color: #ffff00; border-style:dotted; border-width:1px">15.0.0 (draft 1)</span>
+                  <td valign="top">Unicode <span style="background-color: #ffff00; border-style:dotted; border-width:1px">15.0.0 (draft 2)</span>
                   </td>
                </tr>
                <tr>
@@ -45,7 +45,7 @@
                <tr>
                   <td valign="top">Date</td>
                   <td valign="top">
-                     <span style="background-color: #ffff00; border-style:dotted; border-width:1px">2022-03-31</span>
+                     <span style="background-color: #ffff00; border-style:dotted; border-width:1px">2022-05-24</span>
                   </td>
                </tr>
                <tr>
@@ -2294,8 +2294,7 @@
 
   </tt>
             <span style="background-color: #ffff00; border-style:dotted; border-width:1px">code-point-attributes &amp;= attribute kAlternateTotalStrokes
-     { list { ( xsd:string {pattern="[0-9]+:[BHJKMPSUV]+"}
-              | xsd:string {pattern="\-"} ) + }}?</span>
+     { "-" | list { xsd:string {pattern="[0-9]+:[BHJKMPSUV]+"} +}}?</span>
             <tt style="white-space: pre;">
 
   code-point-attributes &amp;= attribute kBigFive
@@ -2471,7 +2470,7 @@
             <tt style="white-space: pre;">
           | xsd:string {pattern="GZ-[0-9]{7}"}
           </tt>
-            <span style="background-color: #ffff00; border-style:dotted; border-width:1px">| xsd:string {pattern="GZA-[123467][0-9]{5}"}</span>
+            <span style="background-color: #ffff00; border-style:dotted; border-width:1px">| xsd:string {pattern="GZA-[0-9]{6}"}</span>
             <tt style="white-space: pre;">
           | xsd:string {pattern="GZFY-[0-9]{5}"}
           | xsd:string {pattern="GZH-[0-9]{4}\.[0-9]{2}"}

--- a/uax42/tr42-31.rnc
+++ b/uax42/tr42-31.rnc
@@ -985,8 +985,7 @@
      { text }?
 
   code-point-attributes &= attribute kAlternateTotalStrokes
-     { list { ( xsd:string {pattern="[0-9]+:[BHJKMPSUV]+"}
-              | xsd:string {pattern="\-"} ) + }}?
+     { "-" | list { xsd:string {pattern="[0-9]+:[BHJKMPSUV]+"} +}}?
 
   code-point-attributes &= attribute kBigFive
      { xsd:string {pattern="[0-9A-F]{4}"} }?
@@ -1158,7 +1157,7 @@
           | xsd:string {pattern="GXHZ-[0-9]{3}"}
           | xsd:string {pattern="GXM-[0-9]{5}"}
           | xsd:string {pattern="GZ-[0-9]{7}"}
-          | xsd:string {pattern="GZA-[123467][0-9]{5}"}
+          | xsd:string {pattern="GZA-[0-9]{6}"}
           | xsd:string {pattern="GZFY-[0-9]{5}"}
           | xsd:string {pattern="GZH-[0-9]{4}\.[0-9]{2}"}
           | xsd:string {pattern="GZJW-[0-9]{5}"}

--- a/uax42/tr42-31.xml
+++ b/uax42/tr42-31.xml
@@ -6,7 +6,7 @@
   <title>Unicode Character Database in XML</title>
 
   <articleinfo>
-    <unicode:tr number='42' class='uax' version='15.0.0 (draft 1)'
+    <unicode:tr number='42' class='uax' version='15.0.0 (draft 2)'
                 stage='proposed-update' status='published'
                 schema='rnc' prevrev='30'/>
 
@@ -21,7 +21,7 @@
     <revhistory>
       <revision>
         <revnumber>31</revnumber>
-        <date>2022-03-31</date>
+        <date>2022-05-24</date>
         <revdescription>
           <itemizedlist>
             <listitem><para>New value for the <sgmltag>age</sgmltag> attribute:
@@ -2487,8 +2487,7 @@
      { text }?
 
   <phrase revisionflag='added'>code-point-attributes &amp;= attribute kAlternateTotalStrokes
-     { list { ( xsd:string {pattern="[0-9]+:[BHJKMPSUV]+"}
-              | xsd:string {pattern="\-"} ) + }}?</phrase>
+     { "-" | list { xsd:string {pattern="[0-9]+:[BHJKMPSUV]+"} +}}?</phrase>
 
   code-point-attributes &amp;= attribute kBigFive
      { xsd:string {pattern="[0-9A-F]{4}"} }?
@@ -2660,7 +2659,7 @@
           | xsd:string {pattern="GXHZ-[0-9]{3}"}
           <phrase revisionflag='added'>| xsd:string {pattern="GXM-[0-9]{5}"}</phrase>
           | xsd:string {pattern="GZ-[0-9]{7}"}
-          <phrase revisionflag='added'>| xsd:string {pattern="GZA-[123467][0-9]{5}"}</phrase>
+          <phrase revisionflag='added'>| xsd:string {pattern="GZA-[0-9]{6}"}</phrase>
           | xsd:string {pattern="GZFY-[0-9]{5}"}
           | xsd:string {pattern="GZH-[0-9]{4}\.[0-9]{2}"}
           | xsd:string {pattern="GZJW-[0-9]{5}"}


### PR DESCRIPTION
UCDXML 15.0 Draft 2 generated from UCD 15.0 Beta as of 2022-05-24
- Simplified kIRG_GSource pattern "GZA-[0-9]{6}"
- Revised kAlternateTotalStrokes expression ("-" or list)
- Validation passed (using rnv.exe)

Thank you, Eric, for the very nice explanations and recommendations.