### PR TITLE
Parse @missing lines in DerivedBidiClass.txt

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -2230,51 +2230,51 @@ of the copyright holder.
     <get src='${Public}/15.0.0/ucd/CJKRadicals-15.0.0d1.txt'                    dest='data/15.0.0/ucd/CJKRadicals.txt'/>
     <get src='${Public}/15.0.0/ucd/CaseFolding-15.0.0d1.txt'                    dest='data/15.0.0/ucd/CaseFolding.txt'/>
     <get src='${Public}/15.0.0/ucd/CompositionExclusions-15.0.0d1.txt'          dest='data/15.0.0/ucd/CompositionExclusions.txt'/>
-    <get src='${Public}/15.0.0/ucd/DerivedAge-15.0.0d2.txt'                     dest='data/15.0.0/ucd/DerivedAge.txt'/>
-    <get src='${Public}/15.0.0/ucd/DerivedCoreProperties-15.0.0d1.txt'          dest='data/15.0.0/ucd/DerivedCoreProperties.txt'/>
+    <get src='${Public}/15.0.0/ucd/DerivedAge-15.0.0d3.txt'                     dest='data/15.0.0/ucd/DerivedAge.txt'/>
+    <get src='${Public}/15.0.0/ucd/DerivedCoreProperties-15.0.0d2.txt'          dest='data/15.0.0/ucd/DerivedCoreProperties.txt'/>
     <get src='${Public}/15.0.0/ucd/DerivedNormalizationProps-15.0.0d1.txt'      dest='data/15.0.0/ucd/DerivedNormalizationProps.txt'/>
     <get src='${Public}/15.0.0/ucd/EastAsianWidth-15.0.0d5.txt'                 dest='data/15.0.0/ucd/EastAsianWidth.txt'/>
     <get src='${Public}/15.0.0/ucd/EmojiSources-15.0.0d1.txt'                   dest='data/15.0.0/ucd/EmojiSources.txt'/>
     <get src='${Public}/15.0.0/ucd/EquivalentUnifiedIdeograph-15.0.0d1.txt'     dest='data/15.0.0/ucd/EquivalentUnifiedIdeograph.txt'/>
     <get src='${Public}/15.0.0/ucd/HangulSyllableType-15.0.0d1.txt'             dest='data/15.0.0/ucd/HangulSyllableType.txt'/>
-    <get src='${Public}/15.0.0/ucd/Index-15.0.0d1.txt'                          dest='data/15.0.0/ucd/Index.txt'/>
-    <get src='${Public}/15.0.0/ucd/IndicPositionalCategory-15.0.0d6.txt'        dest='data/15.0.0/ucd/IndicPositionalCategory.txt'/>
-    <get src='${Public}/15.0.0/ucd/IndicSyllabicCategory-15.0.0d5.txt'          dest='data/15.0.0/ucd/IndicSyllabicCategory.txt'/>
+    <get src='${Public}/15.0.0/ucd/Index-15.0.0d3.txt'                          dest='data/15.0.0/ucd/Index.txt'/>
+    <get src='${Public}/15.0.0/ucd/IndicPositionalCategory-15.0.0d7.txt'        dest='data/15.0.0/ucd/IndicPositionalCategory.txt'/>
+    <get src='${Public}/15.0.0/ucd/IndicSyllabicCategory-15.0.0d6.txt'          dest='data/15.0.0/ucd/IndicSyllabicCategory.txt'/>
     <get src='${Public}/15.0.0/ucd/Jamo-15.0.0d1.txt'                           dest='data/15.0.0/ucd/Jamo.txt'/>
-    <get src='${Public}/15.0.0/ucd/LineBreak-15.0.0d6.txt'                      dest='data/15.0.0/ucd/LineBreak.txt'/>
-    <get src='${Public}/15.0.0/ucd/NameAliases-15.0.0d2.txt'                    dest='data/15.0.0/ucd/NameAliases.txt'/>
+    <get src='${Public}/15.0.0/ucd/LineBreak-15.0.0d8.txt'                      dest='data/15.0.0/ucd/LineBreak.txt'/>
+    <get src='${Public}/15.0.0/ucd/NameAliases-15.0.0d3.txt'                    dest='data/15.0.0/ucd/NameAliases.txt'/>
     <get src='${Public}/15.0.0/ucd/NamedSequences-15.0.0d1.txt'                 dest='data/15.0.0/ucd/NamedSequences.txt'/>
     <get src='${Public}/15.0.0/ucd/NamedSequencesProv-15.0.0d1.txt'             dest='data/15.0.0/ucd/NamedSequencesProv.txt'/>
-    <get src='${Public}/15.0.0/ucd/NamesList-15.0.0d1.html'                     dest='data/15.0.0/ucd/NamesList.html'/>
+    <get src='${Public}/15.0.0/ucd/NamesList-15.0.0d2.html'                     dest='data/15.0.0/ucd/NamesList.html'/>
     <get src='${Public}/15.0.0/ucd/NamesList-15.0.0d5.txt'                      dest='data/15.0.0/ucd/NamesList.txt'/>
     <get src='${Public}/15.0.0/ucd/NormalizationCorrections-15.0.0d1.txt'       dest='data/15.0.0/ucd/NormalizationCorrections.txt'/>
     <get src='${Public}/15.0.0/ucd/NormalizationTest-15.0.0d1.txt'              dest='data/15.0.0/ucd/NormalizationTest.txt'/>
     <get src='${Public}/15.0.0/ucd/NushuSources-15.0.0d1.txt'                   dest='data/15.0.0/ucd/NushuSources.txt'/>
-    <get src='${Public}/15.0.0/ucd/PropList-15.0.0d3.txt'                       dest='data/15.0.0/ucd/PropList.txt'/>
+    <get src='${Public}/15.0.0/ucd/PropList-15.0.0d4.txt'                       dest='data/15.0.0/ucd/PropList.txt'/>
     <get src='${Public}/15.0.0/ucd/PropertyAliases-15.0.0d1.txt'                dest='data/15.0.0/ucd/PropertyAliases.txt'/>
-    <get src='${Public}/15.0.0/ucd/PropertyValueAliases-15.0.0d1.txt'           dest='data/15.0.0/ucd/PropertyValueAliases.txt'/>
+    <get src='${Public}/15.0.0/ucd/PropertyValueAliases-15.0.0d2.txt'           dest='data/15.0.0/ucd/PropertyValueAliases.txt'/>
     <get src='${Public}/15.0.0/ucd/ReadMe-15.0.0d1.txt'                         dest='data/15.0.0/ucd/ReadMe.txt'/>
     <get src='${Public}/15.0.0/ucd/ScriptExtensions-15.0.0d1.txt'               dest='data/15.0.0/ucd/ScriptExtensions.txt'/>
     <get src='${Public}/15.0.0/ucd/Scripts-15.0.0d5.txt'                        dest='data/15.0.0/ucd/Scripts.txt'/>
     <get src='${Public}/15.0.0/ucd/SpecialCasing-15.0.0d1.txt'                  dest='data/15.0.0/ucd/SpecialCasing.txt'/>
     <get src='${Public}/15.0.0/ucd/StandardizedVariants-15.0.0d2.txt'           dest='data/15.0.0/ucd/StandardizedVariants.txt'/>
     <get src='${Public}/15.0.0/ucd/TangutSources-15.0.0d1.txt'                  dest='data/15.0.0/ucd/TangutSources.txt'/>
-    <get src='${Public}/15.0.0/ucd/USourceData-15.0.0d3.txt'                    dest='data/15.0.0/ucd/USourceData.txt'/>
-    <get src='${Public}/15.0.0/ucd/USourceGlyphs-15.0.0d4.pdf'                  dest='data/15.0.0/ucd/USourceGlyphs.pdf'/>
-    <get src='${Public}/15.0.0/ucd/USourceRSChart-15.0.0d4.pdf'                 dest='data/15.0.0/ucd/USourceRSChart.pdf'/>
-    <get src='${Public}/15.0.0/ucd/UnicodeData-15.0.0d6.txt'                    dest='data/15.0.0/ucd/UnicodeData.txt'/>
-    <get src='${Public}/15.0.0/ucd/Unihan-15.0.0d4.zip'                         dest='data/15.0.0/ucd/Unihan.zip'/>
-    <get src='${Public}/15.0.0/ucd/VerticalOrientation-15.0.0d2.txt'            dest='data/15.0.0/ucd/VerticalOrientation.txt'/>
+    <get src='${Public}/15.0.0/ucd/USourceData-15.0.0d5.txt'                    dest='data/15.0.0/ucd/USourceData.txt'/>
+    <get src='${Public}/15.0.0/ucd/USourceGlyphs-15.0.0d5.pdf'                  dest='data/15.0.0/ucd/USourceGlyphs.pdf'/>
+    <get src='${Public}/15.0.0/ucd/USourceRSChart-15.0.0d5.pdf'                 dest='data/15.0.0/ucd/USourceRSChart.pdf'/>
+    <get src='${Public}/15.0.0/ucd/UnicodeData-15.0.0d7.txt'                    dest='data/15.0.0/ucd/UnicodeData.txt'/>
+    <get src='${Public}/15.0.0/ucd/Unihan-15.0.0d5.zip'                         dest='data/15.0.0/ucd/Unihan.zip'/>
+    <get src='${Public}/15.0.0/ucd/VerticalOrientation-15.0.0d3.txt'            dest='data/15.0.0/ucd/VerticalOrientation.txt'/>
 
-    <get src='${Public}/15.0.0/ucd/extracted/DerivedBidiClass-15.0.0d1.txt'             dest='data/15.0.0/ucd/extracted/DerivedBidiClass.txt'/>
+    <get src='${Public}/15.0.0/ucd/extracted/DerivedBidiClass-15.0.0d3.txt'             dest='data/15.0.0/ucd/extracted/DerivedBidiClass.txt'/>
     <get src='${Public}/15.0.0/ucd/extracted/DerivedBinaryProperties-15.0.0d1.txt'      dest='data/15.0.0/ucd/extracted/DerivedBinaryProperties.txt'/>
     <get src='${Public}/15.0.0/ucd/extracted/DerivedCombiningClass-15.0.0d1.txt'        dest='data/15.0.0/ucd/extracted/DerivedCombiningClass.txt'/>
     <get src='${Public}/15.0.0/ucd/extracted/DerivedDecompositionType-15.0.0d1.txt'     dest='data/15.0.0/ucd/extracted/DerivedDecompositionType.txt'/>
-    <get src='${Public}/15.0.0/ucd/extracted/DerivedEastAsianWidth-15.0.0d1.txt'        dest='data/15.0.0/ucd/extracted/DerivedEastAsianWidth.txt'/>
+    <get src='${Public}/15.0.0/ucd/extracted/DerivedEastAsianWidth-15.0.0d2.txt'        dest='data/15.0.0/ucd/extracted/DerivedEastAsianWidth.txt'/>
     <get src='${Public}/15.0.0/ucd/extracted/DerivedGeneralCategory-15.0.0d1.txt'       dest='data/15.0.0/ucd/extracted/DerivedGeneralCategory.txt'/>
     <get src='${Public}/15.0.0/ucd/extracted/DerivedJoiningGroup-15.0.0d1.txt'          dest='data/15.0.0/ucd/extracted/DerivedJoiningGroup.txt'/>
     <get src='${Public}/15.0.0/ucd/extracted/DerivedJoiningType-15.0.0d1.txt'           dest='data/15.0.0/ucd/extracted/DerivedJoiningType.txt'/>
-    <get src='${Public}/15.0.0/ucd/extracted/DerivedLineBreak-15.0.0d2.txt'             dest='data/15.0.0/ucd/extracted/DerivedLineBreak.txt'/>
+    <get src='${Public}/15.0.0/ucd/extracted/DerivedLineBreak-15.0.0d4.txt'             dest='data/15.0.0/ucd/extracted/DerivedLineBreak.txt'/>
     <get src='${Public}/15.0.0/ucd/extracted/DerivedName-15.0.0d1.txt'                  dest='data/15.0.0/ucd/extracted/DerivedName.txt'/>
     <get src='${Public}/15.0.0/ucd/extracted/DerivedNumericType-15.0.0d1.txt'           dest='data/15.0.0/ucd/extracted/DerivedNumericType.txt'/>
     <get src='${Public}/15.0.0/ucd/extracted/DerivedNumericValues-15.0.0d1.txt'         dest='data/15.0.0/ucd/extracted/DerivedNumericValues.txt'/>
@@ -2284,7 +2284,7 @@ of the copyright holder.
     <get src='${Public}/15.0.0/ucd/auxiliary/GraphemeBreakTest-15.0.0d1.txt'            dest='data/15.0.0/ucd/auxiliary/GraphemeBreakTest.txt'/>
     <get src='${Public}/15.0.0/ucd/auxiliary/LineBreakTest-15.0.0d1.html'               dest='data/15.0.0/ucd/auxiliary/LineBreakTest.html'/>
     <get src='${Public}/15.0.0/ucd/auxiliary/LineBreakTest-15.0.0d1.txt'                dest='data/15.0.0/ucd/auxiliary/LineBreakTest.txt'/>
-    <get src='${Public}/15.0.0/ucd/auxiliary/SentenceBreakProperty-15.0.0d1.txt'        dest='data/15.0.0/ucd/auxiliary/SentenceBreakProperty.txt'/>
+    <get src='${Public}/15.0.0/ucd/auxiliary/SentenceBreakProperty-15.0.0d2.txt'        dest='data/15.0.0/ucd/auxiliary/SentenceBreakProperty.txt'/>
     <get src='${Public}/15.0.0/ucd/auxiliary/SentenceBreakTest-15.0.0d1.html'           dest='data/15.0.0/ucd/auxiliary/SentenceBreakTest.html'/>
     <get src='${Public}/15.0.0/ucd/auxiliary/SentenceBreakTest-15.0.0d1.txt'            dest='data/15.0.0/ucd/auxiliary/SentenceBreakTest.txt'/>
     <get src='${Public}/15.0.0/ucd/auxiliary/WordBreakProperty-15.0.0d1.txt'            dest='data/15.0.0/ucd/auxiliary/WordBreakProperty.txt'/>
@@ -2357,7 +2357,8 @@ of the copyright holder.
 
   <target name='compile'>
     <javac srcdir='src' includeantruntime='false'
-           includes='**'>
+           includes='**'
+           debug='true' debuglevel='lines,vars,source'>
       <classpath refid='classpath'/>
     </javac>
   </target>

--- a/src/org/unicode/ucd/Ucd.java
+++ b/src/org/unicode/ucd/Ucd.java
@@ -1061,13 +1061,28 @@ public class Ucd {
   }
 
   private void parseDerivedBidiClass (Version v, URL baseURL) throws Exception {
-    if (v.isAtLeast (Version.V3_2_0)) {
+    if (v.isAtLeast (Version.V15_0_0)) {
+      Parser.parseSemiDelimitedFileWithCodePointsAndAtmissings (baseURL, "extracted/DerivedBidiClass.txt", 0, "US-ASCII",
+        new LoaderWithCodePoints () {
+          public void process (int firstCp, int lastCp, String[] fields) {
+            if ((fields [1]).length () > 3) {
+              if ("Left_To_Right".equals (fields [1])) {
+                fields [1] = "L"; }
+              else if ("Right_To_Left".equals (fields [1])) {
+                fields [1] = "R"; }
+              else if ("Arabic_Letter".equals (fields [1])) {
+                fields [1] = "AL"; }
+              else if ("European_Terminator".equals (fields [1])) {
+                fields [1] = "ET"; }}
+            repertoire.putForced (firstCp, lastCp, Property.bc, fields [1]); }}); }
+
+    else if (v.isAtLeast (Version.V3_2_0)) {
       Parser.parseSemiDelimitedFileWithCodePoints (baseURL, "extracted/DerivedBidiClass.txt", 0, "US-ASCII",
         new LoaderWithCodePoints () {
           public void process (int firstCp, int lastCp, String[] fields) {
-            repertoire.put (firstCp, lastCp, Property.bc, fields [1]); }});
+            repertoire.put (firstCp, lastCp, Property.bc, fields [1]); }}); }
 
-      repertoire.putDefault (Property.bc, "L"); }
+      repertoire.putDefault (Property.bc, "L");
   }
 
   private void parseUnihan (Version v, URL baseURL, boolean numericValuesOnly) throws Exception {

--- a/uax42/index.xml
+++ b/uax42/index.xml
@@ -6,7 +6,7 @@
   <title>Unicode Character Database in XML</title>
 
   <articleinfo>
-    <unicode:tr number='42' class='uax' version='15.0.0 (draft 2)'
+    <unicode:tr number='42' class='uax' version='15.0.0 (draft 3)'
                 stage='proposed-update' status='published'
                 schema='rnc' prevrev='30'/>
 
@@ -17,11 +17,16 @@
       <firstname>Eric</firstname>
       <email>eric.muller@efele.net</email>
     </author>
+    <author revisionflag='added'>
+      <firstname>Lauren&#x021B;iu</firstname>
+      <surname>Iancu</surname>
+      <email>liancu@unicode.org</email>
+    </author>
 
     <revhistory>
       <revision>
         <revnumber>31</revnumber>
-        <date>2022-05-24</date>
+        <date>2022-08-14</date>
         <revdescription>
           <itemizedlist>
             <listitem><para>New value for the <sgmltag>age</sgmltag> attribute:
@@ -779,7 +784,7 @@
       values.</para>
 
       <para>Valid documents may provide values for only some of the
-      the code points, or some of the Unicode properties. Furthermore,
+      code points, or some of the Unicode properties. Furthermore,
       they may also incorporate non-Unicode properties.</para>
 
       <para>Our schema is defined using English. However, a useful
@@ -799,7 +804,7 @@
       schema is relatively straightforward and can be converted
       mechanically to other schema languages.</para>
 
-      <para>While our XML representation is not intented to be used
+      <para>While our XML representation is not intended to be used
       during processing of characters and strings, it is still a
       design principle for our schema to support the relatively
       efficient representation of the UCD. This is achieved by an
@@ -950,7 +955,7 @@
     <section>
       <title>Sets of code points</title>
 
-      <para>It is often the case that successive code points have the
+      <para>It is often the case that successive code points have
       the same property values, for a given set of properties. The
       most striking example is that of an unallocated plane, where all
       but the last two code points are reserved and have the same
@@ -1195,7 +1200,7 @@
       point&gt;. It also happens that character names cannot contain
       the character U+0023 &#x0023; NUMBER SIGN, so we adopted the
       following convention: if a code point has the attribute
-      <sgmltag>na</sgmltag> (either directly or by inheritence from an
+      <sgmltag>na</sgmltag> (either directly or by inheritance from an
       enclosing group), then occurrences of the character # in the
       name are to be interpreted as the value of the code point. For
       example:</para>
@@ -1623,7 +1628,7 @@
         representation of the combining class.</para>
 
         <para>Because the set of values that this property has taken
-        accross the various versions of the UCD is rather large,
+        across the various versions of the UCD is rather large,
         our schema does not restrict the possible values to those
         actually used.</para>
 
@@ -1745,7 +1750,7 @@
         <para>The properties NFC_Quick_Check, NFD_Quick_Check,
         NFKC_Quick_Check, NFKD_Quick_Check, Expands_On_NFC,
         Expands_On_NFD, Expands_On_NFKC, Expands_On_NKFD,
-        FC_NFKC_Closure have corresponding attribues.</para>
+        FC_NFKC_Closure have corresponding attributes.</para>
 
 <lp:scrap title='quick check properties' id='schema.properties'>
   code-point-attributes &amp;=
@@ -1876,7 +1881,7 @@
                  | "Zain" | "Zhain" }?
 </lp:scrap>
 
-        <para>The Join_Control property is representedy by the
+        <para>The Join_Control property is represented by the
         <sgmltag>Join_C</sgmltag> attribute.</para>
 
 <lp:scrap title='joining properties' id='schema.properties'>

--- a/uax42/tr2html.xsl
+++ b/uax42/tr2html.xsl
@@ -374,6 +374,12 @@
   </span>
 </xsl:template>
 
+<xsl:template match='author[@revisionflag="added"]'>
+  <span style='background-color: #ffff00; border-style:dotted; border-width:1px'>
+    <xsl:apply-templates/>
+  </span>
+</xsl:template>
+
 <xsl:template match='phrase[@revisionflag="changed"]'>
   <span style='background-color: #ffff00; border-style:dotted; border-width:1px'>
     <xsl:apply-templates/>

--- a/uax42/tr42-31.html
+++ b/uax42/tr42-31.html
@@ -34,18 +34,23 @@
             <tbody>
                <tr>
                   <td valign="top" width="20%">Version</td>
-                  <td valign="top">Unicode <span style="background-color: #ffff00; border-style:dotted; border-width:1px">15.0.0 (draft 2)</span>
+                  <td valign="top">Unicode <span style="background-color: #ffff00; border-style:dotted; border-width:1px">15.0.0 (draft 3)</span>
                   </td>
                </tr>
                <tr>
-                  <td valign="top">Editor</td>
+                  <td valign="top">Editors</td>
                   <td valign="top">Eric Muller (<a href="mailto:eric.muller@efele.net">eric.muller@efele.net</a>)<br/>
+                     <span style="background-color: #ffff00; border-style:dotted; border-width:1px">
+      Laurențiu
+      Iancu
+       (<a href="mailto:liancu@unicode.org">liancu@unicode.org</a>)
+    </span>
                   </td>
                </tr>
                <tr>
                   <td valign="top">Date</td>
                   <td valign="top">
-                     <span style="background-color: #ffff00; border-style:dotted; border-width:1px">2022-05-24</span>
+                     <span style="background-color: #ffff00; border-style:dotted; border-width:1px">2022-08-14</span>
                   </td>
                </tr>
                <tr>
@@ -137,110 +142,110 @@
          </p>
          <h4>Contents</h4>
          <ul class="toc">
-            <li>1     <a href="#d1e2297">Introduction</a>
+            <li>1     <a href="#d1e2309">Introduction</a>
             </li>
-            <li>2     <a href="#d1e2334">Overall schema</a>
+            <li>2     <a href="#d1e2346">Overall schema</a>
                <ul class="toc">
-                  <li>2.1     <a href="#d1e2341">General principles</a>
+                  <li>2.1     <a href="#d1e2353">General principles</a>
                   </li>
-                  <li>2.2     <a href="#d1e2374">Namespace</a>
+                  <li>2.2     <a href="#d1e2386">Namespace</a>
                   </li>
-                  <li>2.3     <a href="#d1e2398">Datatypes</a>
+                  <li>2.3     <a href="#d1e2410">Datatypes</a>
                   </li>
-                  <li>2.4     <a href="#d1e2430">Root Element</a>
+                  <li>2.4     <a href="#d1e2442">Root Element</a>
                   </li>
-                  <li>2.5     <a href="#d1e2453">Common attributes</a>
+                  <li>2.5     <a href="#d1e2465">Common attributes</a>
                   </li>
-                  <li>2.6     <a href="#d1e2480">Ordering of elements</a>
+                  <li>2.6     <a href="#d1e2492">Ordering of elements</a>
                   </li>
                </ul>
             </li>
-            <li>3     <a href="#d1e2501">Description</a>
+            <li>3     <a href="#d1e2513">Description</a>
             </li>
-            <li>4     <a href="#d1e2533">Repertoire</a>
+            <li>4     <a href="#d1e2545">Repertoire</a>
                <ul class="toc">
-                  <li>4.1     <a href="#d1e2558">Sets of code points</a>
+                  <li>4.1     <a href="#d1e2570">Sets of code points</a>
                   </li>
-                  <li>4.2     <a href="#d1e2600">Code point types</a>
+                  <li>4.2     <a href="#d1e2612">Code point types</a>
                   </li>
                   <li>4.3     <a href="#group">Group</a>
                   </li>
-                  <li>4.4     <a href="#d1e2720">Properties</a>
+                  <li>4.4     <a href="#d1e2732">Properties</a>
                      <ul class="toc">
-                        <li>4.4.1     <a href="#d1e2749">Age property</a>
+                        <li>4.4.1     <a href="#d1e2761">Age property</a>
                         </li>
-                        <li>4.4.2     <a href="#d1e2775">Name properties</a>
+                        <li>4.4.2     <a href="#d1e2787">Name properties</a>
                         </li>
-                        <li>4.4.3     <a href="#d1e2849">Name Aliases</a>
+                        <li>4.4.3     <a href="#d1e2861">Name Aliases</a>
                         </li>
-                        <li>4.4.4     <a href="#d1e2872">Block</a>
+                        <li>4.4.4     <a href="#d1e2884">Block</a>
                         </li>
-                        <li>4.4.5     <a href="#d1e2917">General Category</a>
+                        <li>4.4.5     <a href="#d1e2929">General Category</a>
                         </li>
-                        <li>4.4.6     <a href="#d1e2941">Combining properties</a>
+                        <li>4.4.6     <a href="#d1e2953">Combining properties</a>
                         </li>
-                        <li>4.4.7     <a href="#d1e2967">Bidirectionality properties</a>
+                        <li>4.4.7     <a href="#d1e2979">Bidirectionality properties</a>
                         </li>
-                        <li>4.4.8     <a href="#d1e3058">Decomposition properties</a>
+                        <li>4.4.8     <a href="#d1e3070">Decomposition properties</a>
                         </li>
-                        <li>4.4.9     <a href="#d1e3119">Numeric Properties</a>
+                        <li>4.4.9     <a href="#d1e3131">Numeric Properties</a>
                         </li>
-                        <li>4.4.10     <a href="#d1e3148">Joining properties</a>
+                        <li>4.4.10     <a href="#d1e3160">Joining properties</a>
                         </li>
-                        <li>4.4.11     <a href="#d1e3193">Linebreak properties</a>
+                        <li>4.4.11     <a href="#d1e3205">Linebreak properties</a>
                         </li>
-                        <li>4.4.12     <a href="#d1e3217">East Asian Width property</a>
+                        <li>4.4.12     <a href="#d1e3229">East Asian Width property</a>
                         </li>
-                        <li>4.4.13     <a href="#d1e3240">Case properties</a>
+                        <li>4.4.13     <a href="#d1e3252">Case properties</a>
                         </li>
-                        <li>4.4.14     <a href="#d1e3340">Script properties</a>
+                        <li>4.4.14     <a href="#d1e3352">Script properties</a>
                         </li>
-                        <li>4.4.15     <a href="#d1e3373">ISO Comment properties</a>
+                        <li>4.4.15     <a href="#d1e3385">ISO Comment properties</a>
                         </li>
-                        <li>4.4.16     <a href="#d1e3396">Hangul properties</a>
+                        <li>4.4.16     <a href="#d1e3408">Hangul properties</a>
                         </li>
-                        <li>4.4.17     <a href="#d1e3434">Indic properties</a>
+                        <li>4.4.17     <a href="#d1e3446">Indic properties</a>
                         </li>
-                        <li>4.4.18     <a href="#d1e3489">Identifier and Pattern and programming language properties</a>
+                        <li>4.4.18     <a href="#d1e3501">Identifier and Pattern and programming language properties</a>
                         </li>
-                        <li>4.4.19     <a href="#d1e3521">Properties related to function and graphic characteristics</a>
+                        <li>4.4.19     <a href="#d1e3533">Properties related to function and graphic characteristics</a>
                         </li>
-                        <li>4.4.20     <a href="#d1e3541">Properties related to boundaries</a>
+                        <li>4.4.20     <a href="#d1e3553">Properties related to boundaries</a>
                         </li>
-                        <li>4.4.21     <a href="#d1e3562">Properties related to ideographs</a>
+                        <li>4.4.21     <a href="#d1e3574">Properties related to ideographs</a>
                         </li>
-                        <li>4.4.22     <a href="#d1e3582">Miscellaneous properties</a>
+                        <li>4.4.22     <a href="#d1e3594">Miscellaneous properties</a>
                         </li>
-                        <li>4.4.23     <a href="#d1e3602">Unihan properties</a>
+                        <li>4.4.23     <a href="#d1e3614">Unihan properties</a>
                         </li>
-                        <li>4.4.24     <a href="#d1e3660">Tangut data</a>
+                        <li>4.4.24     <a href="#d1e3672">Tangut data</a>
                         </li>
-                        <li>4.4.25     <a href="#d1e3680">Nushu data</a>
+                        <li>4.4.25     <a href="#d1e3692">Nushu data</a>
                         </li>
-                        <li>4.4.26     <a href="#d1e3700">Emoji properties</a>
+                        <li>4.4.26     <a href="#d1e3712">Emoji properties</a>
                         </li>
                      </ul>
                   </li>
                </ul>
             </li>
-            <li>5     <a href="#d1e3723">Blocks</a>
+            <li>5     <a href="#d1e3735">Blocks</a>
             </li>
-            <li>6     <a href="#d1e3752">Named Sequences</a>
+            <li>6     <a href="#d1e3764">Named Sequences</a>
             </li>
-            <li>7     <a href="#d1e3790">Normalization Corrections</a>
+            <li>7     <a href="#d1e3802">Normalization Corrections</a>
             </li>
-            <li>8     <a href="#d1e3820">Standardized Variants</a>
+            <li>8     <a href="#d1e3832">Standardized Variants</a>
             </li>
-            <li>9     <a href="#d1e3849">CJK Radicals</a>
+            <li>9     <a href="#d1e3861">CJK Radicals</a>
             </li>
-            <li>10     <a href="#d1e3878">Emoji sources</a>
+            <li>10     <a href="#d1e3890">Emoji sources</a>
             </li>
-            <li>11     <a href="#d1e3914">The full schema</a>
+            <li>11     <a href="#d1e3926">The full schema</a>
             </li>
-            <li>12     <a href="#d1e4202">Examples</a>
+            <li>12     <a href="#d1e4214">Examples</a>
             </li>
             <li>
-               <a href="#d1e4216">Acknowledgments</a>
+               <a href="#d1e4228">Acknowledgments</a>
             </li>
             <li>
                <a href="#Modifications">Modifications</a>
@@ -248,7 +253,7 @@
          </ul>
          <hr/>
          <h2>
-            <a name="d1e2297">1 Introduction</a>
+            <a name="d1e2309">1 Introduction</a>
          </h2>
 
          <p>In working on Unicode implementations, it is often useful to
@@ -303,13 +308,13 @@
     Character Database</a>.</p>
   
          <h2>
-            <a name="d1e2334">2 Overall schema</a>
+            <a name="d1e2346">2 Overall schema</a>
          </h2>
 
     
     
          <h3>
-            <a name="d1e2341">2.1 General principles</a>
+            <a name="d1e2353">2.1 General principles</a>
          </h3>
 
          <p>Our schema can be used to create and validate documents
@@ -324,7 +329,7 @@
       values.</p>
 
          <p>Valid documents may provide values for only some of the
-      the code points, or some of the Unicode properties. Furthermore,
+      code points, or some of the Unicode properties. Furthermore,
       they may also incorporate non-Unicode properties.</p>
 
          <p>Our schema is defined using English. However, a useful
@@ -343,7 +348,7 @@
       schema is relatively straightforward and can be converted
       mechanically to other schema languages.</p>
 
-         <p>While our XML representation is not intented to be used
+         <p>While our XML representation is not intended to be used
       during processing of characters and strings, it is still a
       design principle for our schema to support the relatively
       efficient representation of the UCD. This is achieved by an
@@ -364,7 +369,7 @@
     
     
          <h3>
-            <a name="d1e2374">2.2 Namespace</a>
+            <a name="d1e2386">2.2 Namespace</a>
          </h3>
 
          <p>The namespace for our elements is
@@ -373,7 +378,7 @@
 
          <p>
             <i>
-               <a name="lp:d1e2380">[namespace declaration, 1]</a> =</i>
+               <a name="lp:d1e2392">[namespace declaration, 1]</a> =</i>
             <tt style="white-space: pre;">
   default namespace ucd = "http://www.unicode.org/ns/2003/ucd/1.0"
 </tt>
@@ -387,14 +392,14 @@
     
     
          <h3>
-            <a name="d1e2398">2.3 Datatypes</a>
+            <a name="d1e2410">2.3 Datatypes</a>
          </h3>
 
          <p>We use a standard XML Schema datatypes:</p>
 
          <p>
             <i>
-               <a name="lp:d1e2398">[datatypes declaration, 2]</a> =</i>
+               <a name="lp:d1e2410">[datatypes declaration, 2]</a> =</i>
             <tt style="white-space: pre;">
   # default; datatypes xsd = "http://www.w3.org/2001/XMLSchema-datatypes"
 </tt>
@@ -420,7 +425,7 @@
 
          <p>
             <i>
-               <a name="lp:d1e2404">[datatype for code points, 3]</a> =</i>
+               <a name="lp:d1e2416">[datatype for code points, 3]</a> =</i>
             <tt style="white-space: pre;">
   single-code-point = xsd:string { pattern = "(|[1-9A-F]|(10))[0-9A-F]{4}" }
 
@@ -434,7 +439,7 @@
     
     
          <h3>
-            <a name="d1e2430">2.4 Root Element</a>
+            <a name="d1e2442">2.4 Root Element</a>
          </h3>
 
          <p>The root element of valid documents is a
@@ -442,7 +447,7 @@
 
          <p>
             <i>
-               <a name="lp:d1e2421">[schema start, 4]</a> =</i>
+               <a name="lp:d1e2433">[schema start, 4]</a> =</i>
             <tt style="white-space: pre;">
   start =
     element ucd { ucd.content }
@@ -454,7 +459,7 @@
     
     
          <h3>
-            <a name="d1e2453">2.5 Common attributes</a>
+            <a name="d1e2465">2.5 Common attributes</a>
          </h3>
 
          <p>A large number of properties are boolean. We
@@ -463,7 +468,7 @@
 
          <p>
             <i>
-               <a name="lp:d1e2441">[boolean type, 5]</a> =</i>
+               <a name="lp:d1e2453">[boolean type, 5]</a> =</i>
             <tt style="white-space: pre;">
   boolean = "Y" | "N"
 </tt>
@@ -474,7 +479,7 @@
     
     
          <h3>
-            <a name="d1e2480">2.6 Ordering of elements</a>
+            <a name="d1e2492">2.6 Ordering of elements</a>
          </h3>
 
          <p>In elements that hold lists of child elements, such as <tt>repertoire</tt>, <tt>group</tt>, or <tt>standardized-variants</tt>, the schema does not require that the child elements be in any particular order.</p>
@@ -483,7 +488,7 @@
 
   
          <h2>
-            <a name="d1e2501">3 Description</a>
+            <a name="d1e2513">3 Description</a>
          </h2>
 
          <p>The root element may have a <tt>description</tt>
@@ -499,7 +504,7 @@
 
          <p>
             <i>
-               <a name="lp:d1e2489">[description, 6]</a> =</i>
+               <a name="lp:d1e2501">[description, 6]</a> =</i>
             <tt style="white-space: pre;">
   ucd.content &amp;=
     element description { text }?
@@ -507,7 +512,7 @@
          </p>
   
          <h2>
-            <a name="d1e2533">4 Repertoire</a>
+            <a name="d1e2545">4 Repertoire</a>
          </h2>
 
          <p>The <tt>repertoire</tt> child element of the
@@ -517,7 +522,7 @@
 
          <p>
             <i>
-               <a name="lp:d1e2509">[repertoire, 7]</a> =</i>
+               <a name="lp:d1e2521">[repertoire, 7]</a> =</i>
             <tt style="white-space: pre;">
   ucd.content &amp;=
     element repertoire { (code-point | group) + }?
@@ -528,10 +533,10 @@
     
     
          <h3>
-            <a name="d1e2558">4.1 Sets of code points</a>
+            <a name="d1e2570">4.1 Sets of code points</a>
          </h3>
 
-         <p>It is often the case that successive code points have the
+         <p>It is often the case that successive code points have
       the same property values, for a given set of properties. The
       most striking example is that of an unallocated plane, where all
       but the last two code points are reserved and have the same
@@ -552,7 +557,7 @@
 
          <p>
             <i>
-               <a name="lp:d1e2534">[Set of code points, 8]</a> =</i>
+               <a name="lp:d1e2546">[Set of code points, 8]</a> =</i>
             <tt style="white-space: pre;">
   set-of-code-points =
      attribute cp { single-code-point }
@@ -570,7 +575,7 @@
     
     
          <h3>
-            <a name="d1e2600">4.2 Code point types</a>
+            <a name="d1e2612">4.2 Code point types</a>
          </h3>
 
          <p>When thinking about Unicode code points, it is useful to split
@@ -597,7 +602,7 @@
 
          <p>
             <i>
-               <a name="lp:d1e2588">[Code points, 9]</a> =</i>
+               <a name="lp:d1e2600">[Code points, 9]</a> =</i>
             <tt style="white-space: pre;">
   code-point |=
     element reserved {
@@ -692,7 +697,7 @@
 
          <p>
             <i>
-               <a name="lp:d1e2654">[groups, 10]</a> =</i>
+               <a name="lp:d1e2666">[groups, 10]</a> =</i>
             <tt style="white-space: pre;">
   group =
     element group {
@@ -705,7 +710,7 @@
 
     
          <h3>
-            <a name="d1e2720">4.4 Properties</a>
+            <a name="d1e2732">4.4 Properties</a>
          </h3>
 
          <p>Each property, except for the Special_Case_Condition and
@@ -740,7 +745,7 @@
     
     
          <h4>
-            <a name="d1e2749">4.4.1 Age property</a>
+            <a name="d1e2761">4.4.1 Age property</a>
          </h4>
 
          <p>The <tt>age</tt> attribute captures the version
@@ -749,7 +754,7 @@
 
          <p>
             <i>
-               <a name="lp:d1e2698">[age, 11]</a> =</i>
+               <a name="lp:d1e2710">[age, 11]</a> =</i>
             <tt style="white-space: pre;">
   code-point-attributes &amp;= attribute age {
           "1.1"
@@ -778,7 +783,7 @@
     
     
          <h4>
-            <a name="d1e2775">4.4.2 Name properties</a>
+            <a name="d1e2787">4.4.2 Name properties</a>
          </h4>
 
          <p>There are two name properties: the name given by the
@@ -788,7 +793,7 @@
 
          <p>
             <i>
-               <a name="lp:d1e2721">[name pattern, 12]</a> =</i>
+               <a name="lp:d1e2733">[name pattern, 12]</a> =</i>
             <tt style="white-space: pre;">
   character-name = xsd:string { pattern="([A-Z0-9 #\-\(\)]*)|(&lt;control&gt;)" }
 </tt>
@@ -796,7 +801,7 @@
 
          <p>
             <i>
-               <a name="lp:d1e2724">[name properties, 13]</a> =</i>
+               <a name="lp:d1e2736">[name properties, 13]</a> =</i>
             <tt style="white-space: pre;">
   code-point-attributes &amp;= attribute na { character-name }?
   code-point-attributes &amp;= attribute na1 { character-name }?
@@ -808,7 +813,7 @@
       point&gt;. It also happens that character names cannot contain
       the character U+0023 # NUMBER SIGN, so we adopted the
       following convention: if a code point has the attribute
-      <tt>na</tt> (either directly or by inheritence from an
+      <tt>na</tt> (either directly or by inheritance from an
       enclosing group), then occurrences of the character # in the
       name are to be interpreted as the value of the code point. For
       example:</p>
@@ -840,7 +845,7 @@
       
       
         <h4>
-            <a name="d1e2849">4.4.3 Name Aliases</a>
+            <a name="d1e2861">4.4.3 Name Aliases</a>
          </h4>
 
         <p>The Name_Alias property is represented by zero or more
@@ -849,7 +854,7 @@
 
          <p>
             <i>
-               <a name="lp:d1e2780">[name_alias property, 14]</a> =</i>
+               <a name="lp:d1e2792">[name_alias property, 14]</a> =</i>
             <tt style="white-space: pre;">
   code-point-attributes &amp;=
     element name-alias {
@@ -865,7 +870,7 @@
       
       
         <h4>
-            <a name="d1e2872">4.4.4 Block</a>
+            <a name="d1e2884">4.4.4 Block</a>
          </h4>
 
         <p>The Block property is represented by the
@@ -873,7 +878,7 @@
 
          <p>
             <i>
-               <a name="lp:d1e2797">[block property, 15]</a> =</i>
+               <a name="lp:d1e2809">[block property, 15]</a> =</i>
             <tt style="white-space: pre;">
   code-point-attributes &amp;=
     attribute blk { "Adlam"
@@ -1226,7 +1231,7 @@
       
       
         <h4>
-            <a name="d1e2917">4.4.5 General Category</a>
+            <a name="d1e2929">4.4.5 General Category</a>
          </h4>
 
         <p>The general category is represented by the
@@ -1234,7 +1239,7 @@
 
          <p>
             <i>
-               <a name="lp:d1e2836">[gc property, 16]</a> =</i>
+               <a name="lp:d1e2848">[gc property, 16]</a> =</i>
             <tt style="white-space: pre;">
   code-point-attributes &amp;=
     attribute gc { "Lu" | "Ll" | "Lt" | "Lm" | "Lo"
@@ -1252,7 +1257,7 @@
       
       
         <h4>
-            <a name="d1e2941">4.4.6 Combining properties</a>
+            <a name="d1e2953">4.4.6 Combining properties</a>
          </h4>
 
         <p>The combining class is represented by the
@@ -1260,13 +1265,13 @@
         representation of the combining class.</p>
 
         <p>Because the set of values that this property has taken
-        accross the various versions of the UCD is rather large,
+        across the various versions of the UCD is rather large,
         our schema does not restrict the possible values to those
         actually used.</p>
 
          <p>
             <i>
-               <a name="lp:d1e2857">[ccc property, 17]</a> =</i>
+               <a name="lp:d1e2869">[ccc property, 17]</a> =</i>
             <tt style="white-space: pre;">
   code-point-attributes &amp;=
     attribute ccc { xsd:integer { minInclusive="0" maxInclusive="254" }}?
@@ -1278,7 +1283,7 @@
       
       
         <h4>
-            <a name="d1e2967">4.4.7 Bidirectionality properties</a>
+            <a name="d1e2979">4.4.7 Bidirectionality properties</a>
          </h4>
 
         <p>The bidirectional class is represented by the
@@ -1286,7 +1291,7 @@
 
          <p>
             <i>
-               <a name="lp:d1e2874">[bc property, 18]</a> =</i>
+               <a name="lp:d1e2886">[bc property, 18]</a> =</i>
             <tt style="white-space: pre;">
   code-point-attributes &amp;=
     attribute bc { "AL" | "AN"
@@ -1311,7 +1316,7 @@
 
          <p>
             <i>
-               <a name="lp:d1e2883">[bidi_M property, 19]</a> =</i>
+               <a name="lp:d1e2895">[bidi_M property, 19]</a> =</i>
             <tt style="white-space: pre;">
   code-point-attributes &amp;=
     attribute Bidi_M { boolean }?
@@ -1325,7 +1330,7 @@
 
          <p>
             <i>
-               <a name="lp:d1e2893">[bmg property, 20]</a> =</i>
+               <a name="lp:d1e2905">[bmg property, 20]</a> =</i>
             <tt style="white-space: pre;">
   code-point-attributes &amp;=
     attribute bmg    { "" | single-code-point }?
@@ -1344,7 +1349,7 @@
 
          <p>
             <i>
-               <a name="lp:d1e2905">[Bidi_C property, 21]</a> =</i>
+               <a name="lp:d1e2917">[Bidi_C property, 21]</a> =</i>
             <tt style="white-space: pre;">
   code-point-attributes &amp;=
     attribute Bidi_C { boolean }?
@@ -1355,7 +1360,7 @@
 
          <p>
             <i>
-               <a name="lp:d1e2918">[bpt and bpb attributes, 22]</a> =</i>
+               <a name="lp:d1e2930">[bpt and bpb attributes, 22]</a> =</i>
             <tt style="white-space: pre;">
   code-point-attributes &amp;=
     attribute bpt { "o" | "c" | "n" }?
@@ -1370,7 +1375,7 @@
       
       
         <h4>
-            <a name="d1e3058">4.4.8 Decomposition properties</a>
+            <a name="d1e3070">4.4.8 Decomposition properties</a>
          </h4>
 
         <p>The decomposition type and decomposition mapping
@@ -1387,7 +1392,7 @@
 
          <p>
             <i>
-               <a name="lp:d1e2941">[decomposition properties, 23]</a> =</i>
+               <a name="lp:d1e2953">[decomposition properties, 23]</a> =</i>
             <tt style="white-space: pre;">
   code-point-attributes &amp;=
     attribute dt { "can"  | "com" | "enc" | "fin"  | "font" | "fra"
@@ -1405,7 +1410,7 @@
 
          <p>
             <i>
-               <a name="lp:d1e2954">[composition properties, 24]</a> =</i>
+               <a name="lp:d1e2966">[composition properties, 24]</a> =</i>
             <tt style="white-space: pre;">
   code-point-attributes &amp;=
     attribute CE { boolean }?
@@ -1418,11 +1423,11 @@
         <p>The properties NFC_Quick_Check, NFD_Quick_Check,
         NFKC_Quick_Check, NFKD_Quick_Check, Expands_On_NFC,
         Expands_On_NFD, Expands_On_NFKC, Expands_On_NKFD,
-        FC_NFKC_Closure have corresponding attribues.</p>
+        FC_NFKC_Closure have corresponding attributes.</p>
 
          <p>
             <i>
-               <a name="lp:d1e2960">[quick check properties, 25]</a> =</i>
+               <a name="lp:d1e2972">[quick check properties, 25]</a> =</i>
             <tt style="white-space: pre;">
   code-point-attributes &amp;=
     attribute NFC_QC { "Y" | "N" | "M" }?
@@ -1459,7 +1464,7 @@
       
       
         <h4>
-            <a name="d1e3119">4.4.9 Numeric Properties</a>
+            <a name="d1e3131">4.4.9 Numeric Properties</a>
          </h4>
 
         <p>The numeric type is represented by the
@@ -1470,7 +1475,7 @@
 
          <p>
             <i>
-               <a name="lp:d1e2984">[numeric properties, 26]</a> =</i>
+               <a name="lp:d1e2996">[numeric properties, 26]</a> =</i>
             <tt style="white-space: pre;">
   code-point-attributes &amp;=
     attribute nt { "None" | "De" | "Di" | "Nu" }?
@@ -1484,7 +1489,7 @@
       
       
         <h4>
-            <a name="d1e3148">4.4.10 Joining properties</a>
+            <a name="d1e3160">4.4.10 Joining properties</a>
          </h4>
 
         <p>The joining class of a character is represented by the
@@ -1495,7 +1500,7 @@
 
          <p>
             <i>
-               <a name="lp:d1e3007">[joining properties, 27]</a> =</i>
+               <a name="lp:d1e3019">[joining properties, 27]</a> =</i>
             <tt style="white-space: pre;">
   code-point-attributes &amp;=
     attribute jt { "U" | "C" | "T" | "D" | "L" | "R" }?
@@ -1565,12 +1570,12 @@
 </tt>
          </p>
 
-        <p>The Join_Control property is representedy by the
+        <p>The Join_Control property is represented by the
         <tt>Join_C</tt> attribute.</p>
 
          <p>
             <i>
-               <a name="lp:d1e3017">[joining properties, 28]</a> =</i>
+               <a name="lp:d1e3029">[joining properties, 28]</a> =</i>
             <tt style="white-space: pre;">
   code-point-attributes &amp;=
     attribute Join_C { boolean }?
@@ -1581,7 +1586,7 @@
       
       
         <h4>
-            <a name="d1e3193">4.4.11 Linebreak properties</a>
+            <a name="d1e3205">4.4.11 Linebreak properties</a>
          </h4>
 
         <p>The Line_Break property is represented by the
@@ -1589,7 +1594,7 @@
 
          <p>
             <i>
-               <a name="lp:d1e3034">[linebreak property, 29]</a> =</i>
+               <a name="lp:d1e3046">[linebreak property, 29]</a> =</i>
             <tt style="white-space: pre;">
   code-point-attributes &amp;=
     attribute lb { "AI" | "AL"
@@ -1617,7 +1622,7 @@
       
       
         <h4>
-            <a name="d1e3217">4.4.12 East Asian Width property</a>
+            <a name="d1e3229">4.4.12 East Asian Width property</a>
          </h4>
 
         <p>The East Asian width property is represented by the
@@ -1625,7 +1630,7 @@
 
          <p>
             <i>
-               <a name="lp:d1e3052">[ea property, 30]</a> =</i>
+               <a name="lp:d1e3064">[ea property, 30]</a> =</i>
             <tt style="white-space: pre;">
   code-point-attributes &amp;=
     attribute ea { "A" | "F" | "H" | "N" | "Na" | "W" }?
@@ -1636,7 +1641,7 @@
       
       
         <h4>
-            <a name="d1e3240">4.4.13 Case properties</a>
+            <a name="d1e3252">4.4.13 Case properties</a>
          </h4>
 
         <p>The Uppercase, Lowercase, Other_Uppercase and
@@ -1645,7 +1650,7 @@
 
          <p>
             <i>
-               <a name="lp:d1e3066">[casing properties, 31]</a> =</i>
+               <a name="lp:d1e3078">[casing properties, 31]</a> =</i>
             <tt style="white-space: pre;">
   code-point-attributes &amp;=
     attribute Upper { boolean }?
@@ -1676,7 +1681,7 @@
 
          <p>
             <i>
-               <a name="lp:d1e3085">[casing properties, 32]</a> =</i>
+               <a name="lp:d1e3097">[casing properties, 32]</a> =</i>
             <tt style="white-space: pre;">
   code-point-attributes &amp;=
     attribute suc { "#" | single-code-point }?
@@ -1695,7 +1700,7 @@
 
          <p>
             <i>
-               <a name="lp:d1e3100">[casing properties, 33]</a> =</i>
+               <a name="lp:d1e3112">[casing properties, 33]</a> =</i>
             <tt style="white-space: pre;">
   code-point-attributes &amp;=
     attribute uc { "#" | one-or-more-code-points }?
@@ -1714,7 +1719,7 @@
 
          <p>
             <i>
-               <a name="lp:d1e3112">[casing properties, 34]</a> =</i>
+               <a name="lp:d1e3124">[casing properties, 34]</a> =</i>
             <tt style="white-space: pre;">
   code-point-attributes &amp;=
     attribute scf { "#" | single-code-point }?
@@ -1733,7 +1738,7 @@
 
          <p>
             <i>
-               <a name="lp:d1e3119">[casing properties, 35]</a> =</i>
+               <a name="lp:d1e3131">[casing properties, 35]</a> =</i>
             <tt style="white-space: pre;">
   code-point-attributes &amp;=
     attribute CI { boolean }?
@@ -1772,7 +1777,7 @@
       
       
         <h4>
-            <a name="d1e3340">4.4.14 Script properties</a>
+            <a name="d1e3352">4.4.14 Script properties</a>
          </h4>
 
         <p>The script and script extension properties are represented by the
@@ -1780,7 +1785,7 @@
 
          <p>
             <i>
-               <a name="lp:d1e3142">[script property, 36]</a> =</i>
+               <a name="lp:d1e3154">[script property, 36]</a> =</i>
             <tt style="white-space: pre;">
   script = "Adlm" | "Aghb" | "Ahom" | "Arab" | "Armi" | "Armn" | "Avst"
          | "Bali" | "Bamu" | "Bass" | "Batk" | "Beng" | "Bhks"
@@ -1838,7 +1843,7 @@
       
       
         <h4>
-            <a name="d1e3373">4.4.15 ISO Comment properties</a>
+            <a name="d1e3385">4.4.15 ISO Comment properties</a>
          </h4>
 
         <p>The ISO 10646 comment field is represented by the
@@ -1846,7 +1851,7 @@
 
          <p>
             <i>
-               <a name="lp:d1e3166">[isc property, 37]</a> =</i>
+               <a name="lp:d1e3178">[isc property, 37]</a> =</i>
             <tt style="white-space: pre;">
   code-point-attributes &amp;=
     attribute isc { text }?
@@ -1857,7 +1862,7 @@
       
       
         <h4>
-            <a name="d1e3396">4.4.16 Hangul properties</a>
+            <a name="d1e3408">4.4.16 Hangul properties</a>
          </h4>
 
         <p>The property Hangul_Syllable_Type is represented by the
@@ -1865,7 +1870,7 @@
 
          <p>
             <i>
-               <a name="lp:d1e3183">[hst property, 38]</a> =</i>
+               <a name="lp:d1e3195">[hst property, 38]</a> =</i>
             <tt style="white-space: pre;">
   code-point-attributes &amp;=
     attribute hst { "L" | "LV" | "LVT" | "T" | "V" | "NA" }?
@@ -1877,7 +1882,7 @@
 
          <p>
             <i>
-               <a name="lp:d1e3192">[jamo property, 39]</a> =</i>
+               <a name="lp:d1e3204">[jamo property, 39]</a> =</i>
             <tt style="white-space: pre;">
   code-point-attributes &amp;=
      attribute JSN { xsd:string { pattern="[A-Z]{0,3}" }}?
@@ -1888,7 +1893,7 @@
       
       
         <h4>
-            <a name="d1e3434">4.4.17 Indic properties</a>
+            <a name="d1e3446">4.4.17 Indic properties</a>
          </h4>
 
         <p>The property Indic_Syllabic_Category is represented by the
@@ -1896,7 +1901,7 @@
 
          <p>
             <i>
-               <a name="lp:d1e3209">[InSC property, 40]</a> =</i>
+               <a name="lp:d1e3221">[InSC property, 40]</a> =</i>
             <tt style="white-space: pre;">
   code-point-attributes &amp;=
     attribute InSC { "Avagraha"
@@ -1944,7 +1949,7 @@
 
          <p>
             <i>
-               <a name="lp:d1e3218">[InMC property, 41]</a> =</i>
+               <a name="lp:d1e3230">[InMC property, 41]</a> =</i>
             <tt style="white-space: pre;">
   code-point-attributes &amp;=
      attribute InMC { "Right"
@@ -1970,7 +1975,7 @@
 
          <p>
             <i>
-               <a name="lp:d1e3228">[InPC property, 42]</a> =</i>
+               <a name="lp:d1e3240">[InPC property, 42]</a> =</i>
             <tt style="white-space: pre;">
   code-point-attributes &amp;=
      attribute InPC { "Bottom"
@@ -1996,7 +2001,7 @@
       
       
         <h4>
-            <a name="d1e3489">4.4.18 Identifier and Pattern and programming language properties</a>
+            <a name="d1e3501">4.4.18 Identifier and Pattern and programming language properties</a>
          </h4>
 
         <p>The properties ID_Start, Other_ID_Start, XID_Start ,
@@ -2005,7 +2010,7 @@
 
          <p>
             <i>
-               <a name="lp:d1e3243">[identifier properties, 43]</a> =</i>
+               <a name="lp:d1e3255">[identifier properties, 43]</a> =</i>
             <tt style="white-space: pre;">
   code-point-attributes &amp;=
     attribute IDS { boolean }?
@@ -2032,7 +2037,7 @@
 
          <p>
             <i>
-               <a name="lp:d1e3249">[pattern properties, 44]</a> =</i>
+               <a name="lp:d1e3261">[pattern properties, 44]</a> =</i>
             <tt style="white-space: pre;">
   code-point-attributes &amp;=
     attribute Pat_Syn { boolean }?
@@ -2047,7 +2052,7 @@
       
       
         <h4>
-            <a name="d1e3521">4.4.19 Properties related to function and graphic characteristics</a>
+            <a name="d1e3533">4.4.19 Properties related to function and graphic characteristics</a>
          </h4>
 
         <p>The properties Dash, Hyphen, Quotation_Mark,
@@ -2062,7 +2067,7 @@
 
          <p>
             <i>
-               <a name="lp:d1e3263">[properties related to function and graphic characteristics, 45]</a> =</i>
+               <a name="lp:d1e3275">[properties related to function and graphic characteristics, 45]</a> =</i>
             <tt style="white-space: pre;">
   code-point-attributes &amp;=
     attribute Dash { boolean }?
@@ -2133,7 +2138,7 @@
       
       
         <h4>
-            <a name="d1e3541">4.4.20 Properties related to boundaries</a>
+            <a name="d1e3553">4.4.20 Properties related to boundaries</a>
          </h4>
 
         <p>The properties Grapheme_Base, Grapheme_Extend,
@@ -2143,7 +2148,7 @@
 
          <p>
             <i>
-               <a name="lp:d1e3277">[properties related to boundaries, 46]</a> =</i>
+               <a name="lp:d1e3289">[properties related to boundaries, 46]</a> =</i>
             <tt style="white-space: pre;">
   code-point-attributes &amp;=
     attribute Gr_Base { boolean }?
@@ -2206,7 +2211,7 @@
       
       
         <h4>
-            <a name="d1e3562">4.4.21 Properties related to ideographs</a>
+            <a name="d1e3574">4.4.21 Properties related to ideographs</a>
          </h4>
 
         <p>The properties Ideographic, Unified_Ideograph,
@@ -2216,7 +2221,7 @@
 
          <p>
             <i>
-               <a name="lp:d1e3292">[properties related to ideographs, 47]</a> =</i>
+               <a name="lp:d1e3304">[properties related to ideographs, 47]</a> =</i>
             <tt style="white-space: pre;">
   code-point-attributes &amp;=
     attribute Ideo { boolean }?
@@ -2242,7 +2247,7 @@
       
       
         <h4>
-            <a name="d1e3582">4.4.22 Miscellaneous properties</a>
+            <a name="d1e3594">4.4.22 Miscellaneous properties</a>
          </h4>
 
         <p>The properties Deprecated, Variation_Selector, and
@@ -2250,7 +2255,7 @@
 
          <p>
             <i>
-               <a name="lp:d1e3306">[miscellaneous properties, 48]</a> =</i>
+               <a name="lp:d1e3318">[miscellaneous properties, 48]</a> =</i>
             <tt style="white-space: pre;">
   code-point-attributes &amp;=
     attribute Dep { boolean }?
@@ -2267,7 +2272,7 @@
       
       
         <h4>
-            <a name="d1e3602">4.4.23 Unihan properties</a>
+            <a name="d1e3614">4.4.23 Unihan properties</a>
          </h4>
 
         <p>The Unihan properties (from the Unihan database) are represented
@@ -2275,7 +2280,7 @@
 
          <p>
             <i>
-               <a name="lp:d1e3320">[Unihan properties, 49]</a> =</i>
+               <a name="lp:d1e3332">[Unihan properties, 49]</a> =</i>
             <tt style="white-space: pre;">
   code-point-attributes &amp;= attribute kAccountingNumeric
      { xsd:string {pattern="[0-9]+"} }?
@@ -2781,14 +2786,14 @@ code-point-attributes &amp;= attribute kSpecializedSemanticVariant
       
       
         <h4>
-            <a name="d1e3660">4.4.24 Tangut data</a>
+            <a name="d1e3672">4.4.24 Tangut data</a>
          </h4>
 
         <p>The Tangut data are represented as attributes.</p>
 
          <p>
             <i>
-               <a name="lp:d1e3372">[Tangut data, 50]</a> =</i>
+               <a name="lp:d1e3384">[Tangut data, 50]</a> =</i>
             <tt style="white-space: pre;">
   code-point-attributes &amp;= attribute kRSTUnicode
      { xsd:string {pattern="[0-9]+\.[0-9]+"} }?
@@ -2812,14 +2817,14 @@ code-point-attributes &amp;= attribute kSpecializedSemanticVariant
       
       
         <h4>
-            <a name="d1e3680">4.4.25 Nushu data</a>
+            <a name="d1e3692">4.4.25 Nushu data</a>
          </h4>
 
         <p>The Nushu data are represented as attributes.</p>
 
          <p>
             <i>
-               <a name="lp:d1e3386">[Nushu data, 51]</a> =</i>
+               <a name="lp:d1e3398">[Nushu data, 51]</a> =</i>
             <tt style="white-space: pre;">
   code-point-attributes &amp;= attribute kSrc_NushuDuben
      { xsd:string {pattern="[0-9]+\.[0-9]+"} }?
@@ -2834,14 +2839,14 @@ code-point-attributes &amp;= attribute kSpecializedSemanticVariant
       
       
         <h4>
-            <a name="d1e3700">4.4.26 Emoji properties</a>
+            <a name="d1e3712">4.4.26 Emoji properties</a>
          </h4>
 
         <p>The Emoji properties are represented as attributes.</p>
 
          <p>
             <i>
-               <a name="lp:d1e3400">[Emoji properties, 52]</a> =</i>
+               <a name="lp:d1e3412">[Emoji properties, 52]</a> =</i>
             <tt style="white-space: pre;">
 
   code-point-attributes &amp;= attribute Emoji { boolean }?
@@ -2857,7 +2862,7 @@ code-point-attributes &amp;= attribute kSpecializedSemanticVariant
     
   
          <h2>
-            <a name="d1e3723">5 Blocks</a>
+            <a name="d1e3735">5 Blocks</a>
          </h2>
 
          <p>The <tt>blocks</tt> child of the
@@ -2867,7 +2872,7 @@ code-point-attributes &amp;= attribute kSpecializedSemanticVariant
 
          <p>
             <i>
-               <a name="lp:d1e3426">[blocks, 53]</a> =</i>
+               <a name="lp:d1e3438">[blocks, 53]</a> =</i>
             <tt style="white-space: pre;">
   ucd.content &amp;=
     element blocks {
@@ -2879,7 +2884,7 @@ code-point-attributes &amp;= attribute kSpecializedSemanticVariant
          </p>
   
          <h2>
-            <a name="d1e3752">6 Named Sequences</a>
+            <a name="d1e3764">6 Named Sequences</a>
          </h2>
 
          <p>The <tt>named-sequences</tt> child of the
@@ -2894,7 +2899,7 @@ code-point-attributes &amp;= attribute kSpecializedSemanticVariant
 
          <p>
             <i>
-               <a name="lp:d1e3458">[named sequences, 54]</a> =</i>
+               <a name="lp:d1e3470">[named sequences, 54]</a> =</i>
             <tt style="white-space: pre;">
   ucd.content &amp;=
     element named-sequences {
@@ -2911,7 +2916,7 @@ code-point-attributes &amp;= attribute kSpecializedSemanticVariant
          </p>
   
          <h2>
-            <a name="d1e3790">7 Normalization Corrections</a>
+            <a name="d1e3802">7 Normalization Corrections</a>
          </h2>
 
          <p>The <tt>normalization-corrections</tt> child of
@@ -2924,7 +2929,7 @@ code-point-attributes &amp;= attribute kSpecializedSemanticVariant
 
          <p>
             <i>
-               <a name="lp:d1e3481">[normalization corrections, 55]</a> =</i>
+               <a name="lp:d1e3493">[normalization corrections, 55]</a> =</i>
             <tt style="white-space: pre;">
   ucd.content &amp;=
     element normalization-corrections {
@@ -2937,7 +2942,7 @@ code-point-attributes &amp;= attribute kSpecializedSemanticVariant
          </p>
   
          <h2>
-            <a name="d1e3820">8 Standardized Variants</a>
+            <a name="d1e3832">8 Standardized Variants</a>
          </h2>
 
          <p>The <tt>standardized-variants</tt> child of the
@@ -2949,7 +2954,7 @@ code-point-attributes &amp;= attribute kSpecializedSemanticVariant
 
          <p>
             <i>
-               <a name="lp:d1e3505">[standardized variants, 56]</a> =</i>
+               <a name="lp:d1e3517">[standardized variants, 56]</a> =</i>
             <tt style="white-space: pre;">
   ucd.content &amp;=
     element standardized-variants {
@@ -2961,7 +2966,7 @@ code-point-attributes &amp;= attribute kSpecializedSemanticVariant
          </p>
   
          <h2>
-            <a name="d1e3849">9 CJK Radicals</a>
+            <a name="d1e3861">9 CJK Radicals</a>
          </h2>
 
          <p>The <tt>cjk-radicals</tt> child of the
@@ -2973,7 +2978,7 @@ code-point-attributes &amp;= attribute kSpecializedSemanticVariant
 
          <p>
             <i>
-               <a name="lp:d1e3528">[cjk radicals, 57]</a> =</i>
+               <a name="lp:d1e3540">[cjk radicals, 57]</a> =</i>
             <tt style="white-space: pre;">
   ucd.content &amp;=
     element cjk-radicals {
@@ -2985,7 +2990,7 @@ code-point-attributes &amp;= attribute kSpecializedSemanticVariant
          </p>
   
          <h2>
-            <a name="d1e3878">10 Emoji sources</a>
+            <a name="d1e3890">10 Emoji sources</a>
          </h2>
 
          <p>The <tt>emoji-sources</tt> child of the
@@ -2993,7 +2998,7 @@ code-point-attributes &amp;= attribute kSpecializedSemanticVariant
 
          <p>
             <i>
-               <a name="lp:d1e3548">[datatype for code points, 58]</a> =</i>
+               <a name="lp:d1e3560">[datatype for code points, 58]</a> =</i>
             <tt style="white-space: pre;">
   jis-code-point = xsd:string { pattern = "[0-9A-F]{4}" }
 </tt>
@@ -3002,7 +3007,7 @@ code-point-attributes &amp;= attribute kSpecializedSemanticVariant
 
          <p>
             <i>
-               <a name="lp:d1e3551">[emoji sources, 59]</a> =</i>
+               <a name="lp:d1e3563">[emoji sources, 59]</a> =</i>
             <tt style="white-space: pre;">
   ucd.content &amp;=
     element emoji-sources {
@@ -3016,7 +3021,7 @@ code-point-attributes &amp;= attribute kSpecializedSemanticVariant
 
   
          <h2>
-            <a name="d1e3914">11 The full schema</a>
+            <a name="d1e3926">11 The full schema</a>
          </h2>
 
          <p>Our schema is just the accumulation of the pieces we have
@@ -3024,55 +3029,55 @@ code-point-attributes &amp;= attribute kSpecializedSemanticVariant
 
          <p>
             <i>
-               <a name="lp:d1e3566">[UCD RelaxNG schema, 60]</a> =</i>
+               <a name="lp:d1e3578">[UCD RelaxNG schema, 60]</a> =</i>
             <tt style="white-space: pre;">
       </tt>
-            <i>[namespace declaration: <a href="#lp:d1e2380">1</a>]</i>
+            <i>[namespace declaration: <a href="#lp:d1e2392">1</a>]</i>
             <tt style="white-space: pre;">
       </tt>
-            <i>[datatypes: <a href="#lp:d1e2398">2</a>, <a href="#lp:d1e2404">3</a>, <a href="#lp:d1e2721">12</a>, <a href="#lp:d1e3548">58</a>]</i>
+            <i>[datatypes: <a href="#lp:d1e2410">2</a>, <a href="#lp:d1e2416">3</a>, <a href="#lp:d1e2733">12</a>, <a href="#lp:d1e3560">58</a>]</i>
             <tt style="white-space: pre;">
       </tt>
-            <i>[schema start: <a href="#lp:d1e2421">4</a>]</i>
+            <i>[schema start: <a href="#lp:d1e2433">4</a>]</i>
             <tt style="white-space: pre;">
       </tt>
-            <i>[boolean type: <a href="#lp:d1e2441">5</a>]</i>
+            <i>[boolean type: <a href="#lp:d1e2453">5</a>]</i>
             <tt style="white-space: pre;">
       </tt>
-            <i>[description: <a href="#lp:d1e2489">6</a>]</i>
+            <i>[description: <a href="#lp:d1e2501">6</a>]</i>
             <tt style="white-space: pre;">
       </tt>
-            <i>[repertoire: <a href="#lp:d1e2509">7</a>, <a href="#lp:d1e2534">8</a>, <a href="#lp:d1e2588">9</a>, <a href="#lp:d1e2654">10</a>]</i>
+            <i>[repertoire: <a href="#lp:d1e2521">7</a>, <a href="#lp:d1e2546">8</a>, <a href="#lp:d1e2600">9</a>, <a href="#lp:d1e2666">10</a>]</i>
             <tt style="white-space: pre;">
       </tt>
-            <i>[attributes: <a href="#lp:d1e2698">11</a>, <a href="#lp:d1e2724">13</a>, <a href="#lp:d1e2780">14</a>, <a href="#lp:d1e2797">15</a>, <a href="#lp:d1e2836">16</a>, <a href="#lp:d1e2857">17</a>, <a href="#lp:d1e2874">18</a>, <a href="#lp:d1e2883">19</a>, <a href="#lp:d1e2893">20</a>, <a href="#lp:d1e2905">21</a>, <a href="#lp:d1e2918">22</a>, <a href="#lp:d1e2941">23</a>, <a href="#lp:d1e2954">24</a>, <a href="#lp:d1e2960">25</a>, <a href="#lp:d1e2984">26</a>, <a href="#lp:d1e3007">27</a>, <a href="#lp:d1e3017">28</a>, <a href="#lp:d1e3034">29</a>, <a href="#lp:d1e3052">30</a>, <a href="#lp:d1e3066">31</a>, <a href="#lp:d1e3085">32</a>, <a href="#lp:d1e3100">33</a>, <a href="#lp:d1e3112">34</a>, <a href="#lp:d1e3119">35</a>, <a href="#lp:d1e3142">36</a>, <a href="#lp:d1e3166">37</a>, <a href="#lp:d1e3183">38</a>, <a href="#lp:d1e3192">39</a>, <a href="#lp:d1e3209">40</a>, <a href="#lp:d1e3218">41</a>, <a href="#lp:d1e3228">42</a>, <a href="#lp:d1e3243">43</a>, <a href="#lp:d1e3249">44</a>, <a href="#lp:d1e3263">45</a>, <a href="#lp:d1e3277">46</a>, <a href="#lp:d1e3292">47</a>, <a href="#lp:d1e3306">48</a>, <a href="#lp:d1e3320">49</a>]</i>
+            <i>[attributes: <a href="#lp:d1e2710">11</a>, <a href="#lp:d1e2736">13</a>, <a href="#lp:d1e2792">14</a>, <a href="#lp:d1e2809">15</a>, <a href="#lp:d1e2848">16</a>, <a href="#lp:d1e2869">17</a>, <a href="#lp:d1e2886">18</a>, <a href="#lp:d1e2895">19</a>, <a href="#lp:d1e2905">20</a>, <a href="#lp:d1e2917">21</a>, <a href="#lp:d1e2930">22</a>, <a href="#lp:d1e2953">23</a>, <a href="#lp:d1e2966">24</a>, <a href="#lp:d1e2972">25</a>, <a href="#lp:d1e2996">26</a>, <a href="#lp:d1e3019">27</a>, <a href="#lp:d1e3029">28</a>, <a href="#lp:d1e3046">29</a>, <a href="#lp:d1e3064">30</a>, <a href="#lp:d1e3078">31</a>, <a href="#lp:d1e3097">32</a>, <a href="#lp:d1e3112">33</a>, <a href="#lp:d1e3124">34</a>, <a href="#lp:d1e3131">35</a>, <a href="#lp:d1e3154">36</a>, <a href="#lp:d1e3178">37</a>, <a href="#lp:d1e3195">38</a>, <a href="#lp:d1e3204">39</a>, <a href="#lp:d1e3221">40</a>, <a href="#lp:d1e3230">41</a>, <a href="#lp:d1e3240">42</a>, <a href="#lp:d1e3255">43</a>, <a href="#lp:d1e3261">44</a>, <a href="#lp:d1e3275">45</a>, <a href="#lp:d1e3289">46</a>, <a href="#lp:d1e3304">47</a>, <a href="#lp:d1e3318">48</a>, <a href="#lp:d1e3332">49</a>]</i>
             <tt style="white-space: pre;">
       </tt>
-            <i>[Tangut data: <a href="#lp:d1e3372">50</a>]</i>
+            <i>[Tangut data: <a href="#lp:d1e3384">50</a>]</i>
             <tt style="white-space: pre;">
       </tt>
-            <i>[Nushu data: <a href="#lp:d1e3386">51</a>]</i>
+            <i>[Nushu data: <a href="#lp:d1e3398">51</a>]</i>
             <tt style="white-space: pre;">
       </tt>
-            <i>[blocks: <a href="#lp:d1e3426">53</a>]</i>
+            <i>[blocks: <a href="#lp:d1e3438">53</a>]</i>
             <tt style="white-space: pre;">
       </tt>
-            <i>[named sequences: <a href="#lp:d1e3458">54</a>]</i>
+            <i>[named sequences: <a href="#lp:d1e3470">54</a>]</i>
             <tt style="white-space: pre;">
       </tt>
-            <i>[normalization corrections: <a href="#lp:d1e3481">55</a>]</i>
+            <i>[normalization corrections: <a href="#lp:d1e3493">55</a>]</i>
             <tt style="white-space: pre;">
       </tt>
-            <i>[standardized variants: <a href="#lp:d1e3505">56</a>]</i>
+            <i>[standardized variants: <a href="#lp:d1e3517">56</a>]</i>
             <tt style="white-space: pre;">
       </tt>
-            <i>[cjk radicals: <a href="#lp:d1e3528">57</a>]</i>
+            <i>[cjk radicals: <a href="#lp:d1e3540">57</a>]</i>
             <tt style="white-space: pre;">
       </tt>
-            <i>[emoji sources: <a href="#lp:d1e3551">59</a>]</i>
+            <i>[emoji sources: <a href="#lp:d1e3563">59</a>]</i>
             <tt style="white-space: pre;">
       </tt>
-            <i>[Emoji properties: <a href="#lp:d1e3400">52</a>]</i>
+            <i>[Emoji properties: <a href="#lp:d1e3412">52</a>]</i>
             <tt style="white-space: pre;">
     </tt>
          </p>
@@ -3081,7 +3086,7 @@ code-point-attributes &amp;= attribute kSpecializedSemanticVariant
 
   
          <h2>
-            <a name="d1e4202">12 Examples</a>
+            <a name="d1e4214">12 Examples</a>
          </h2>
 
          <p>Here is a fragment of the UCD for a few representative
@@ -3123,7 +3128,7 @@ code-point-attributes &amp;= attribute kSpecializedSemanticVariant
 
   
     <h2>
-            <a name="d1e4216">Acknowledgments</a>
+            <a name="d1e4228">Acknowledgments</a>
          </h2>
          <p>Thanks to Markus Scherer and Mark Davis for their help
     developing this XML representation. Thanks to the reviewers: Julie

--- a/uax42/tr42-31.xml
+++ b/uax42/tr42-31.xml
@@ -6,7 +6,7 @@
   <title>Unicode Character Database in XML</title>
 
   <articleinfo>
-    <unicode:tr number='42' class='uax' version='15.0.0 (draft 2)'
+    <unicode:tr number='42' class='uax' version='15.0.0 (draft 3)'
                 stage='proposed-update' status='published'
                 schema='rnc' prevrev='30'/>
 
@@ -17,11 +17,16 @@
       <firstname>Eric</firstname>
       <email>eric.muller@efele.net</email>
     </author>
+    <author revisionflag='added'>
+      <firstname>Lauren&#x021B;iu</firstname>
+      <surname>Iancu</surname>
+      <email>liancu@unicode.org</email>
+    </author>
 
     <revhistory>
       <revision>
         <revnumber>31</revnumber>
-        <date>2022-05-24</date>
+        <date>2022-08-14</date>
         <revdescription>
           <itemizedlist>
             <listitem><para>New value for the <sgmltag>age</sgmltag> attribute:
@@ -779,7 +784,7 @@
       values.</para>
 
       <para>Valid documents may provide values for only some of the
-      the code points, or some of the Unicode properties. Furthermore,
+      code points, or some of the Unicode properties. Furthermore,
       they may also incorporate non-Unicode properties.</para>
 
       <para>Our schema is defined using English. However, a useful
@@ -799,7 +804,7 @@
       schema is relatively straightforward and can be converted
       mechanically to other schema languages.</para>
 
-      <para>While our XML representation is not intented to be used
+      <para>While our XML representation is not intended to be used
       during processing of characters and strings, it is still a
       design principle for our schema to support the relatively
       efficient representation of the UCD. This is achieved by an
@@ -950,7 +955,7 @@
     <section>
       <title>Sets of code points</title>
 
-      <para>It is often the case that successive code points have the
+      <para>It is often the case that successive code points have
       the same property values, for a given set of properties. The
       most striking example is that of an unallocated plane, where all
       but the last two code points are reserved and have the same
@@ -1195,7 +1200,7 @@
       point&gt;. It also happens that character names cannot contain
       the character U+0023 &#x0023; NUMBER SIGN, so we adopted the
       following convention: if a code point has the attribute
-      <sgmltag>na</sgmltag> (either directly or by inheritence from an
+      <sgmltag>na</sgmltag> (either directly or by inheritance from an
       enclosing group), then occurrences of the character # in the
       name are to be interpreted as the value of the code point. For
       example:</para>
@@ -1623,7 +1628,7 @@
         representation of the combining class.</para>
 
         <para>Because the set of values that this property has taken
-        accross the various versions of the UCD is rather large,
+        across the various versions of the UCD is rather large,
         our schema does not restrict the possible values to those
         actually used.</para>
 
@@ -1745,7 +1750,7 @@
         <para>The properties NFC_Quick_Check, NFD_Quick_Check,
         NFKC_Quick_Check, NFKD_Quick_Check, Expands_On_NFC,
         Expands_On_NFD, Expands_On_NFKC, Expands_On_NKFD,
-        FC_NFKC_Closure have corresponding attribues.</para>
+        FC_NFKC_Closure have corresponding attributes.</para>
 
 <lp:scrap title='quick check properties' id='schema.properties'>
   code-point-attributes &amp;=
@@ -1876,7 +1881,7 @@
                  | "Zain" | "Zhain" }?
 </lp:scrap>
 
-        <para>The Join_Control property is representedy by the
+        <para>The Join_Control property is represented by the
         <sgmltag>Join_C</sgmltag> attribute.</para>
 
 <lp:scrap title='joining properties' id='schema.properties'>


### PR DESCRIPTION
Changes:
- Update parseDerivedBidiClass() to support multiple `@missing` lines in extracted/DerivedBidiClass.txt.  A recent change in that file replaced the explicit listing of non-default bc values for unassigned code points with a list of `@missing` lines.
- Fix typos in UAX #42, per https://www.unicode.org/L2/L2022/22020-edcom-rept-utc170.html.  See https://www.unicode.org/L2/L2022/22016.htm#170-A13.

Notes:
- The bc output has been verified by comparing the diffs to those generated before the UCD changed.
- The generated XML data has not been schema validated.  That will be done in the next regeneration.