### PR TITLE
UCDXML 15.0 Release Candidate - update links

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -2246,14 +2246,14 @@ of the copyright holder.
     <get src='${Public}/15.0.0/ucd/NamedSequences-15.0.0d1.txt'                 dest='data/15.0.0/ucd/NamedSequences.txt'/>
     <get src='${Public}/15.0.0/ucd/NamedSequencesProv-15.0.0d1.txt'             dest='data/15.0.0/ucd/NamedSequencesProv.txt'/>
     <get src='${Public}/15.0.0/ucd/NamesList-15.0.0d2.html'                     dest='data/15.0.0/ucd/NamesList.html'/>
-    <get src='${Public}/15.0.0/ucd/NamesList-15.0.0d6.txt'                      dest='data/15.0.0/ucd/NamesList.txt'/>
+    <get src='${Public}/15.0.0/ucd/NamesList-15.0.0d7.txt'                      dest='data/15.0.0/ucd/NamesList.txt'/>
     <get src='${Public}/15.0.0/ucd/NormalizationCorrections-15.0.0d1.txt'       dest='data/15.0.0/ucd/NormalizationCorrections.txt'/>
     <get src='${Public}/15.0.0/ucd/NormalizationTest-15.0.0d1.txt'              dest='data/15.0.0/ucd/NormalizationTest.txt'/>
     <get src='${Public}/15.0.0/ucd/NushuSources-15.0.0d1.txt'                   dest='data/15.0.0/ucd/NushuSources.txt'/>
     <get src='${Public}/15.0.0/ucd/PropList-15.0.0d4.txt'                       dest='data/15.0.0/ucd/PropList.txt'/>
     <get src='${Public}/15.0.0/ucd/PropertyAliases-15.0.0d1.txt'                dest='data/15.0.0/ucd/PropertyAliases.txt'/>
     <get src='${Public}/15.0.0/ucd/PropertyValueAliases-15.0.0d2.txt'           dest='data/15.0.0/ucd/PropertyValueAliases.txt'/>
-    <get src='${Public}/15.0.0/ucd/ReadMe-15.0.0d1.txt'                         dest='data/15.0.0/ucd/ReadMe.txt'/>
+    <get src='${Public}/15.0.0/ucd/ReadMe-15.0.0d2.txt'                         dest='data/15.0.0/ucd/ReadMe.txt'/>
     <get src='${Public}/15.0.0/ucd/ScriptExtensions-15.0.0d1.txt'               dest='data/15.0.0/ucd/ScriptExtensions.txt'/>
     <get src='${Public}/15.0.0/ucd/Scripts-15.0.0d5.txt'                        dest='data/15.0.0/ucd/Scripts.txt'/>
     <get src='${Public}/15.0.0/ucd/SpecialCasing-15.0.0d1.txt'                  dest='data/15.0.0/ucd/SpecialCasing.txt'/>

--- a/uax42/index.xml
+++ b/uax42/index.xml
@@ -26,7 +26,7 @@
     <revhistory>
       <revision>
         <revnumber>32</revnumber>
-        <date>2022-08-26</date>
+        <date>2022-09-04</date>
         <revdescription>
           <itemizedlist>
             <listitem><para>New value for the <sgmltag>age</sgmltag> attribute:
@@ -759,7 +759,7 @@
 
     <para>This annex presents only the XML representation format of
     the UCD. The data itself is part of the <ulink
-    url='https://www.unicode.org/reports/tr41/tr41-28.html#UCD'>Unicode
+    url='https://www.unicode.org/reports/tr41/tr41-30.html#UCD'>Unicode
     Character Database</ulink>.</para>
   </section>
 
@@ -791,7 +791,7 @@
       subset of the validity constraints can be captured using a
       schema language, thereby simplifying the task of validating
       documents. We have chosen Relax NG [<ulink
-      url='https://www.unicode.org/reports/tr41/tr41-28.html#ISO19757'>ISO
+      url='https://www.unicode.org/reports/tr41/tr41-30.html#ISO19757'>ISO
       19757</ulink>], in the compact syntax , as the schema
       language. It is important to stress that the schema which is
       defined in English imposes more constraints on the documents
@@ -926,7 +926,7 @@
       represent the UCD of some Unicode version, the
       <sgmltag>description</sgmltag> be selected in accord with the
       rules listed in <ulink
-      url='https://www.unicode.org/reports/tr41/tr41-28.html#Versions'>[Versions]</ulink>; and
+      url='https://www.unicode.org/reports/tr41/tr41-30.html#Versions'>[Versions]</ulink>; and
       conversely, that documents which do not purport to represent the
       UCD be described as such.</para>
 

--- a/uax42/tr42-32.html
+++ b/uax42/tr42-32.html
@@ -45,7 +45,7 @@
                <tr>
                   <td valign="top">Date</td>
                   <td valign="top">
-                     <span>2022-08-26</span>
+                     <span>2022-09-04</span>
                   </td>
                </tr>
                <tr>
@@ -296,7 +296,7 @@
     can be useful when only some of the data is needed.</p>
 
          <p>This annex presents only the XML representation format of
-    the UCD. The data itself is part of the <a href="https://www.unicode.org/reports/tr41/tr41-28.html#UCD">Unicode
+    the UCD. The data itself is part of the <a href="https://www.unicode.org/reports/tr41/tr41-30.html#UCD">Unicode
     Character Database</a>.</p>
   
          <h2>
@@ -327,7 +327,7 @@
          <p>Our schema is defined using English. However, a useful
       subset of the validity constraints can be captured using a
       schema language, thereby simplifying the task of validating
-      documents. We have chosen Relax NG [<a href="https://www.unicode.org/reports/tr41/tr41-28.html#ISO19757">ISO
+      documents. We have chosen Relax NG [<a href="https://www.unicode.org/reports/tr41/tr41-30.html#ISO19757">ISO
       19757</a>], in the compact syntax , as the schema
       language. It is important to stress that the schema which is
       defined in English imposes more constraints on the documents
@@ -490,7 +490,7 @@
          <p>It is recommended that if the document purports to
       represent the UCD of some Unicode version, the
       <tt>description</tt> be selected in accord with the
-      rules listed in <a href="https://www.unicode.org/reports/tr41/tr41-28.html#Versions">[Versions]</a>; and
+      rules listed in <a href="https://www.unicode.org/reports/tr41/tr41-30.html#Versions">[Versions]</a>; and
       conversely, that documents which do not purport to represent the
       UCD be described as such.</p>
 

--- a/uax42/tr42-32.xml
+++ b/uax42/tr42-32.xml
@@ -26,7 +26,7 @@
     <revhistory>
       <revision>
         <revnumber>32</revnumber>
-        <date>2022-08-26</date>
+        <date>2022-09-04</date>
         <revdescription>
           <itemizedlist>
             <listitem><para>New value for the <sgmltag>age</sgmltag> attribute:
@@ -759,7 +759,7 @@
 
     <para>This annex presents only the XML representation format of
     the UCD. The data itself is part of the <ulink
-    url='https://www.unicode.org/reports/tr41/tr41-28.html#UCD'>Unicode
+    url='https://www.unicode.org/reports/tr41/tr41-30.html#UCD'>Unicode
     Character Database</ulink>.</para>
   </section>
 
@@ -791,7 +791,7 @@
       subset of the validity constraints can be captured using a
       schema language, thereby simplifying the task of validating
       documents. We have chosen Relax NG [<ulink
-      url='https://www.unicode.org/reports/tr41/tr41-28.html#ISO19757'>ISO
+      url='https://www.unicode.org/reports/tr41/tr41-30.html#ISO19757'>ISO
       19757</ulink>], in the compact syntax , as the schema
       language. It is important to stress that the schema which is
       defined in English imposes more constraints on the documents
@@ -926,7 +926,7 @@
       represent the UCD of some Unicode version, the
       <sgmltag>description</sgmltag> be selected in accord with the
       rules listed in <ulink
-      url='https://www.unicode.org/reports/tr41/tr41-28.html#Versions'>[Versions]</ulink>; and
+      url='https://www.unicode.org/reports/tr41/tr41-30.html#Versions'>[Versions]</ulink>; and
       conversely, that documents which do not purport to represent the
       UCD be described as such.</para>
 


### PR DESCRIPTION
Minor updates:
- Links to tr41-30.html
- UCD files as of 2022-09-03 (did not result in changes in the UCDXML files)

Note:
- Generated tr42-32.html is the same as [tr42-32d1a.html](https://www.unicode.org/reports/tr42/tr42-32d1a.html) except for the date